### PR TITLE
Get config from .github/stale.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,35 @@
 
 Inspired by @parkr's [auto-reply](https://github.com/parkr/auto-reply#optional-mark-and-sweep-stale-issues) bot that runs @jekyllbot.
 
+## Configuration
+
+Configuration in `.github/stale.yml` can override these defaults:
+
+```yml
+# Number of days of inactivity before an issue becomes stale
+days: 60
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+```
+
 ## TODO:
 
 - [x] On an interval:
   - [x] Get all installations & repositories
   - [x] Run mark & sweep
 - [x] on relevant issue activity: unmark
-- [ ] Get config from repo or org
+- [x] Get config from repo
 - [ ] Deploy demo instance
 - [ ] Add docs on usage/deployment
 - [ ] Release v1.0

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,5 +1,5 @@
 module.exports = {
-  ttl: 60 * 24 * 60 * 60 * 100, // 60 days
+  ttl: 60 * 24 * 60 * 60 * 1000, // 60 days
   exemptLabels: ['pinned', 'security'],
   staleLabel: 'stale',
   perform: !process.env.DRY_RUN,

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,5 +1,5 @@
 module.exports = {
-  ttl: 60 * 24 * 60 * 60 * 1000, // 60 days
+  days: 60,
   exemptLabels: ['pinned', 'security'],
   staleLabel: 'stale',
   perform: !process.env.DRY_RUN,

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -33,7 +33,7 @@ module.exports = class Stale {
       per_page: 100
     };
 
-    this.logger.info('searching %s/%s for stale issues', owner, repo);
+    this.logger.debug(params, 'searching %s/%s for stale issues', owner, repo);
     return this.github.search.issues(params);
   }
 
@@ -99,6 +99,7 @@ module.exports = class Stale {
   }
 
   get since() {
-    return new Date(new Date() - this.config.ttl);
+    const ttl = this.config.days * 24 * 60 * 60 * 1000;
+    return new Date(new Date() - ttl);
   }
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "xo"
   },
   "dependencies": {
+    "js-yaml": "^3.8.2",
     "probot": "probot/probot"
   },
   "engines": {


### PR DESCRIPTION
Configuration in `.github/stale.yml` can override these defaults:

```yml
# Number of days of inactivity before an issue becomes stale
days: 60
# Issues with these labels will never be considered stale
exemptLabels:
  - pinned
  - security
# Label to use when marking an issue as stale
staleLabel: wontfix
# Comment to post when marking an issue as stale. Set to `false` to disable
markComment: >
  This issue has been automatically marked as stale because it has not had
  recent activity. It will be closed if no further activity occurs. Thank you
  for your contributions.
# Comment to post when closing a stale issue. Set to `false` to disable
closeComment: false
```

cc @lee-dohm 