### PR TITLE
Dry-run on repos without a config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ Inspired by @parkr's [auto-reply](https://github.com/parkr/auto-reply#optional-m
 
 ## Usage
 
-**[Configure the GitHub Integration](https://github.com/integration/probot-stale)**
-
-> **Heads Up!** This integration will run as soon as you install it on your repository. If you want to change any of the settings, do it before installing.
+1. **[Configure the GitHub Integration](https://github.com/integration/probot-stale)**
+2. Create `.github/stale.yml`
 
 Configuration in `.github/stale.yml` can override these defaults:
 

--- a/index.js
+++ b/index.js
@@ -74,7 +74,8 @@ module.exports = async robot => {
       const data = await github.repos.getContent({owner, repo, path});
       config = yaml.load(new Buffer(data.content, 'base64').toString());
     } catch (err) {
-      config = {};
+      // Don't actually perform for repository without a config
+      config = {perform: false};
     }
 
     config = Object.assign(config, {owner, repo, logger: robot.log});


### PR DESCRIPTION
This is a hotfix for #2 because it's already proven disorienting for the bot to run on a repo on install.