### PR TITLE
Separate timeframes for stale and close activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Configuration in `.github/stale.yml` can override these defaults:
 
 ```yml
 # Number of days of inactivity before an issue becomes stale
-days: 60
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,5 +1,6 @@
 module.exports = {
-  days: 60,
+  daysUntilStale: 60,
+  daysUntilClose: 7,
   exemptLabels: ['pinned', 'security'],
   staleLabel: 'wontfix',
   perform: !process.env.DRY_RUN,

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -49,10 +49,6 @@ module.exports = class Stale {
     return this.github.search.issues(params);
   }
 
-  hasStaleLabel(issue) {
-    return issue.labels.map(label => label.name).includes(this.config.staleLabel);
-  }
-
   mark(issue) {
     const {owner, repo, staleLabel, markComment, perform} = this.config;
     const number = issue.number;
@@ -97,13 +93,13 @@ module.exports = class Stale {
     }
   }
 
-  recentlyUpdated(issue) {
-    return Date.parse(issue.updated_at) >= this.since;
-  }
-
   // Returns true if at least one exempt label is present.
   hasExemptLabel(issue) {
     return issue.labels.some(label => this.config.exemptLabels.includes(label.name));
+  }
+
+  hasStaleLabel(issue) {
+    return issue.labels.map(label => label.name).includes(this.config.staleLabel);
   }
 
   async ensureStaleLabelExists() {

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -12,25 +12,34 @@ module.exports = class Stale {
 
     await this.ensureStaleLabelExists();
 
-    this.getIssues().then(paginate(this.github, data => {
-      data.items.forEach(issue => {
-        if (this.isStale(issue)) {
-          if (this.hasStaleLabel(issue)) {
-            return this.close(issue);
-          } else {
-            return this.mark(issue);
-          }
-        }
-      });
+    this.getStaleIssues().then(paginate(this.github, data => {
+      data.items.forEach(issue => this.mark(issue));
+    }));
+
+    this.getClosableIssues().then(paginate(this.github, data => {
+      data.items.forEach(issue => this.close(issue));
     }));
   }
 
-  async getIssues() {
-    const timestamp = this.since.toISOString().replace(/\.\d{3}\w$/, '');
+  getStaleIssues() {
+    const labels = [this.config.staleLabel].concat(this.config.exemptLabels);
+    const query = labels.map(label => `-label:${label}`).join(' ');
+    const days = this.config.daysUntilStale || this.config.days;
+    return this.search(days, query);
+  }
+
+  getClosableIssues() {
+    const query = `label:${this.config.staleLabel}`;
+    const days = this.config.daysUntilClose || this.config.days;
+    return this.search(days, query);
+  }
+
+  search(days, query) {
     const {owner, repo} = this.config;
+    const timestamp = this.since(days).toISOString().replace(/\.\d{3}\w$/, '');
 
     const params = {
-      q: `repo:${owner}/${repo} is:issue is:open updated:<${timestamp}`,
+      q: `repo:${owner}/${repo} is:issue is:open updated:<${timestamp} ${query}`,
       sort: 'updated',
       order: 'desc',
       per_page: 100
@@ -38,10 +47,6 @@ module.exports = class Stale {
 
     this.logger.debug(params, 'searching %s/%s for stale issues', owner, repo);
     return this.github.search.issues(params);
-  }
-
-  isStale(issue) {
-    return !this.recentlyUpdated(issue) && !this.hasExemptLabel(issue);
   }
 
   hasStaleLabel(issue) {
@@ -109,8 +114,8 @@ module.exports = class Stale {
     });
   }
 
-  get since() {
-    const ttl = this.config.days * 24 * 60 * 60 * 1000;
+  since(days) {
+    const ttl = days * 24 * 60 * 60 * 1000;
     return new Date(new Date() - ttl);
   }
 };

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -24,13 +24,13 @@ module.exports = class Stale {
   getStaleIssues() {
     const labels = [this.config.staleLabel].concat(this.config.exemptLabels);
     const query = labels.map(label => `-label:${label}`).join(' ');
-    const days = this.config.daysUntilStale || this.config.days;
+    const days = this.config.days || this.config.daysUntilStale;
     return this.search(days, query);
   }
 
   getClosableIssues() {
     const query = `label:${this.config.staleLabel}`;
-    const days = this.config.daysUntilClose || this.config.days;
+    const days = this.config.days || this.config.daysUntilClose;
     return this.search(days, query);
   }
 


### PR DESCRIPTION
Replaces `days` config with 2 separate configs:

```yml
# Number of days of inactivity before an issue becomes stale
daysUntilStale: 60
# Number of days of inactivity before a stale issue is closed
daysUntilClose: 7
```

Fixes #12 @rafaelfranca