### PR TITLE
Document explicit permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,7 @@ Inspired by @parkr's [auto-reply](https://github.com/parkr/auto-reply#optional-m
 1. **[Configure the GitHub Integration](https://github.com/integration/probot-stale)**
 2. Create `.github/stale.yml`
 
-The presence of a `.github/stale.yml` file is required for the probot/stale to act on a repository. An empty `.github/stale.yml` file will
-cause the integration to run using the defaults.
-
-Configuration in `.github/stale.yml` can override these defaults:
+A `.github/stale.yml` file is required to enable the plugin. The file can be empty, or it can override any of these default settings:
 
 ```yml
 # Configuration for probot-stale - https://github.com/probot/stale

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Inspired by @parkr's [auto-reply](https://github.com/parkr/auto-reply#optional-m
 1. **[Configure the GitHub Integration](https://github.com/integration/probot-stale)**
 2. Create `.github/stale.yml`
 
+The presence of a `.github/stale.yml` file is required for the probot/stale to act on a repository. An empty `.github/stale.yml` file will
+cause the integration to run using the defaults.
+
 Configuration in `.github/stale.yml` can override these defaults:
 
 ```yml


### PR DESCRIPTION
Without a `.github/stale.yml` file, the integration will remain
inactive.

@bkeepers not sure about the wording, it might be a bit klunky.