### PR TITLE
Stop visiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = async robot => {
     if (!context.isBot) {
       const github = await robot.auth(event.payload.installation.id);
       const stale = await forRepository(github, event.payload.repository);
-      const issue = event.payload.issue;
+      const issue = event.payload.issue || event.payload.pull_request;
 
       if (stale.hasStaleLabel(issue)) {
         stale.unmark(issue);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const Stale = require('./lib/stale');
 
 module.exports = async robot => {
   // Visit all repositories to mark and sweep stale issues
-  visitor(robot, markAndSweep);
+  const visit = visitor(robot, markAndSweep);
 
   // Unmark stale issues if a user comments
   robot.on('issue_comment', unmark);
@@ -54,6 +54,7 @@ module.exports = async robot => {
       const data = await github.repos.getContent({owner, repo, path});
       config = yaml.load(new Buffer(data.content, 'base64').toString());
     } catch (err) {
+      visit.stop(repository);
       // Don't actually perform for repository without a config
       config = {perform: false};
     }


### PR DESCRIPTION
Fixes for a couple common sources of errors in the logs:

1. If a repo does not have a config, stop checking every hour
2. When activity happens on a PR, look for the `pull_request` payload.