### PR TITLE
Comment when removing stale label

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ markComment: >
   This issue has been automatically marked as stale because it has not had
   recent activity. It will be closed if no further activity occurs. Thank you
   for your contributions.
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
 # Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
 closeComment: false
 # Limit to only `issues` or `pulls`

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -7,5 +7,6 @@ module.exports = {
   markComment: 'This issue has been automatically marked as stale because ' +
     'it has not had recent activity. It will be closed if no further ' +
     'activity occurs. Thank you for your contributions.',
+  unmarkComment: false,
   closeComment: false
 };

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -83,12 +83,17 @@ module.exports = class Stale {
   }
 
   unmark(issue) {
-    const {owner, repo, perform, staleLabel} = this.config;
+    const {owner, repo, perform, staleLabel, unmarkComment} = this.config;
     const number = issue.number;
 
     if (perform) {
       this.logger.info('%s/%s#%d is being unmarked', owner, repo, number);
-      return this.github.issues.removeLabel({owner, repo, number, name: staleLabel});
+      return this.github.issues.removeLabel({owner, repo, number, name: staleLabel}).then(() => {
+        if (unmarkComment) {
+          return this.github.issues.createComment({owner, repo, number, body: unmarkComment});
+        }
+      });
+
     } else {
       this.logger.info('%s/%s#%d would have been unmarked (dry-run)', owner, repo, number);
     }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "js-yaml": "^3.8.2",
-    "probot": "^0.3",
-    "probot-visitor": "^0.1"
+    "probot": "^0.4.1",
+    "probot-visitor": "^0.1.1"
   },
   "engines": {
     "node": ">= 7.7.0",


### PR DESCRIPTION
This adds an `unmarkComment` config that will be posted when the stale label is removed:

```yml
unmarkComment: Thanks for commenting. This issue is no longer marked as stale.
```

Fixes #20 

cc @rallytime