### PR TITLE
Wrap labels on quotes

### DIFF
--- a/lib/stale.js
+++ b/lib/stale.js
@@ -21,7 +21,7 @@ module.exports = class Stale {
 
   getStaleIssues() {
     const labels = [this.config.staleLabel].concat(this.config.exemptLabels);
-    const query = labels.map(label => `-label:${label}`).join(' ');
+    const query = labels.map(label => `-label:"${label}"`).join(' ');
     const days = this.config.days || this.config.daysUntilStale;
     return this.search(days, query);
   }


### PR DESCRIPTION
Some labels can have spaces on it and without quotes the query string will be invalid.

The previous code was generating invalid queries when the label contained spaces and no issues were being returned.

I tested in my ruby on rails integration (I deployed a different integration to be able to debug).