### PR TITLE
Don't unmark in a few situations

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = async robot => {
         issue = await github.issues.get(context.issue());
       }
 
-      if (stale.hasStaleLabel(issue)) {
+      if (stale.hasStaleLabel(issue) && issue.state != 'closed') {
         stale.unmark(issue);
       }
     }

--- a/index.js
+++ b/index.js
@@ -24,7 +24,10 @@ module.exports = async robot => {
         issue = await github.issues.get(context.issue());
       }
 
-      if (stale.hasStaleLabel(issue) && issue.state != 'closed') {
+      const staleLabelAdded = event.payload.action === 'labeled' &&
+        event.payload.label.name === stale.config.staleLabel;
+
+      if (stale.hasStaleLabel(issue) && issue.state !== 'closed' && !staleLabelAdded) {
         stale.unmark(issue);
       }
     }


### PR DESCRIPTION
This fixes #18 by adding two guards:

1. Don't unmark if the issue is closed
2. Don't unmark if the stale label was just added

cc @kytrinyx @kotp
