### PR TITLE
(WIP) Support label whitelisting

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = async robot => {
         context.payload.label.name === stale.config.staleLabel;
 
       if (stale.hasStaleLabel(issue) && issue.state !== 'closed' && !staleLabelAdded) {
-        stale.unmark(issue);
+        stale.unmarkIssue(issue);
       }
     }
   }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,6 +1,7 @@
 module.exports = {
   daysUntilStale: 60,
   daysUntilClose: 7,
+  onlyLabels: [],
   exemptLabels: ['pinned', 'security'],
   staleLabel: 'wontfix',
   perform: !process.env.DRY_RUN,

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -10,28 +10,54 @@ module.exports = class Stale {
 
     await this.ensureStaleLabelExists();
 
-    this.github.paginate(this.getStaleIssues(), res => {
-      res.data.items.filter(issue => !issue.locked)
-                .forEach(issue => this.mark(issue));
-    });
+    this.mark();
+    this.sweep();
+  }
 
-    this.github.paginate(this.getClosableIssues(), res => {
+  mark() {
+    const staleDays = this.config.days || this.config.daysUntilStale;
+
+    var markedIssues = new Set()
+
+    this.getStaleIssuesSearches(staleDays).forEach(search =>
+      this.github.paginate(search, res => {
+        res.data.items.filter(issue => !issue.locked)
+                  .filter(issue => !markedIssues.includes(issue))
+                  .forEach(issue => this.mark(issue))
+                  .forEach(issue => markedIssues.add(issue));
+      })
+    );
+  }
+
+  sweep() {
+    const closeDays = this.config.days || this.config.daysUntilClose;
+
+    this.github.paginate(this.getClosableIssuesSearch(), res => {
       res.data.items.filter(issue => !issue.locked)
                 .forEach(issue => this.close(issue));
     });
   }
 
-  getStaleIssues() {
-    const labels = [this.config.staleLabel].concat(this.config.exemptLabels);
-    const query = labels.map(label => `-label:"${label}"`).join(' ');
-    const days = this.config.days || this.config.daysUntilStale;
-    return this.search(days, query);
+  getStaleIssuesSearches(staleDays) {
+    const onlyLabels = this.config.onlyLabels;
+
+    if (onlyLabels.length == 0) {
+      const labels = [this.config.staleLabel].concat(this.config.exemptLabels);
+      const query = labels.map(label => `-label:"${label}"`).join(' ');
+      return [this.search(staleDays, query)];
+    } else {
+      return onlyLabels.map(label => this.getStaleIssuesSearch(staleDays, label));
+    }
   }
 
-  getClosableIssues() {
-    const query = `label:"${this.config.staleLabel}"`;
-    const days = this.config.days || this.config.daysUntilClose;
-    return this.search(days, query);
+  getStaleIssuesSearch(staleDays, label) {
+    const query = `label:"${label}" -label:"${this.config.staleLabel}"`;
+    return this.search(staleDays, query);
+  }
+
+  getClosableIssuesSearch(closeDays) {
+    const query = `label:$"{this.config.staleLabel}"`;
+    return this.search(closeDays, query);
   }
 
   search(days, query) {

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -23,7 +23,7 @@ module.exports = class Stale {
       this.github.paginate(search, res => {
         res.data.items.filter(issue => !issue.locked)
                   .filter(issue => !markedIssues.includes(issue))
-                  .forEach(issue => this.mark(issue))
+                  .forEach(issue => this.markIssue(issue))
                   .forEach(issue => markedIssues.add(issue));
       })
     );
@@ -78,7 +78,7 @@ module.exports = class Stale {
     return this.github.search.issues(params);
   }
 
-  mark(issue) {
+  markIssue(issue) {
     const {owner, repo, staleLabel, markComment, perform} = this.config;
     const number = issue.number;
 
@@ -110,7 +110,7 @@ module.exports = class Stale {
     }
   }
 
-  unmark(issue) {
+  unmarkIssue(issue) {
     const {owner, repo, perform, staleLabel, unmarkComment} = this.config;
     const number = issue.number;
 


### PR DESCRIPTION
_Work in progress; seeking feedback._

---

Closes #22.

**Goals**

This PR represents work towards supporting label whitelisting. The plugin currently supports label blacklisting only.

**Notes**

- Whitelist can be specified using the `onlyLabels` configuration entry;
- If a consumer specifies both `onlyLabels` and `exemptLabels`, `onlyLabels` takes priority and `exemptLabels` is ignored ([[1](https://github.com/probot/stale/issues/22#issuecomment-303118331)], [[2](https://github.com/probot/stale/issues/22#issuecomment-303818347)]).
- New functionality has been designed to leave default plugin behavior unchanged.

**Challenges**

Currently, when the initial mark and sweep occurs, I see the following error:

```
16:10:58.167Z ERROR PRobot: Cannot read property 'number' of undefined
  TypeError: Cannot read property 'number' of undefined
      at Stale.mark (/Users/stkent/dev/personal/probot/stale/lib/stale.js:83:25)
      at Stale.markAndSweep (/Users/stkent/dev/personal/probot/stale/lib/stale.js:13:10)
      at process._tickDomainCallback (internal/process/next_tick.js:135:7)
```

This suggests to me that I'm not handling asynchronous calls properly in my changes. (Reminder: not a JS dev!) I'll add some inline comments after opening this PR explaining my current theories. Looking for feedback/pointers on how I might fix and improve this code ❤️ .