### PR TITLE
Use latest probot and github client

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = async robot => {
 
       // Some payloads don't include labels
       if (!issue.labels) {
-        issue = await context.github.issues.get(context.issue());
+        issue = (await context.github.issues.get(context.issue())).data;
       }
 
       const staleLabelAdded = event.payload.action === 'labeled' &&

--- a/index.js
+++ b/index.js
@@ -59,8 +59,8 @@ module.exports = async robot => {
     let config;
 
     try {
-      const data = await github.repos.getContent({owner, repo, path});
-      config = yaml.load(new Buffer(data.content, 'base64').toString()) || {};
+      const res = await github.repos.getContent({owner, repo, path});
+      config = yaml.load(new Buffer(res.data.content, 'base64').toString()) || {};
     } catch (err) {
       visit.stop(repository);
       // Don't actually perform for repository without a config

--- a/index.js
+++ b/index.js
@@ -15,13 +15,12 @@ module.exports = async robot => {
 
   async function unmark(event, context) {
     if (!context.isBot) {
-      const github = await robot.auth(event.payload.installation.id);
-      const stale = await forRepository(github, event.payload.repository);
+      const stale = await forRepository(context.github, event.payload.repository);
       let issue = event.payload.issue || event.payload.pull_request;
 
       // Some payloads don't include labels
       if (!issue.labels) {
-        issue = await github.issues.get(context.issue());
+        issue = await context.github.issues.get(context.issue());
       }
 
       const staleLabelAdded = event.payload.action === 'labeled' &&
@@ -35,8 +34,7 @@ module.exports = async robot => {
 
   // Unmark stale issues if an exempt label is added
   robot.on('issues.labeled', async event => {
-    const github = await robot.auth(event.payload.installation.id);
-    const stale = await forRepository(github, event.payload.repository);
+    const stale = await forRepository(context.github, event.payload.repository);
     const issue = event.payload.issue;
 
     if (stale.hasStaleLabel(issue) && stale.hasExemptLabel(issue)) {

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = async robot => {
   }
 
   // Unmark stale issues if an exempt label is added
-  robot.on('issues.labeled', async event => {
+  robot.on('issues.labeled', async (event, context) => {
     const stale = await forRepository(context.github, event.payload.repository);
     const issue = event.payload.issue;
 

--- a/index.js
+++ b/index.js
@@ -32,16 +32,6 @@ module.exports = async robot => {
     }
   }
 
-  // Unmark stale issues if an exempt label is added
-  robot.on('issues.labeled', async (event, context) => {
-    const stale = await forRepository(context.github, event.payload.repository);
-    const issue = event.payload.issue;
-
-    if (stale.hasStaleLabel(issue) && stale.hasExemptLabel(issue)) {
-      stale.unmark(issue);
-    }
-  });
-
   async function markAndSweep(installation, repository) {
     const github = await robot.auth(installation.id);
     const stale = await forRepository(github, repository);

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -10,13 +10,13 @@ module.exports = class Stale {
 
     await this.ensureStaleLabelExists();
 
-    this.github.paginate(this.getStaleIssues(), data => {
-      data.items.filter(issue => !issue.locked)
+    this.github.paginate(this.getStaleIssues(), res => {
+      res.data.items.filter(issue => !issue.locked)
                 .forEach(issue => this.mark(issue));
     });
 
-    this.github.paginate(this.getClosableIssues(), data => {
-      data.items.filter(issue => !issue.locked)
+    this.github.paginate(this.getClosableIssues(), res => {
+      res.data.items.filter(issue => !issue.locked)
                 .forEach(issue => this.close(issue));
     });
   }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "js-yaml": "^3.8.2",
-    "probot": "^0.4.1",
-    "probot-visitor": "^0.1.1"
+    "probot": "probot/probot",
+    "probot-visitor": "probot/visitor"
   },
   "engines": {
     "node": ">= 7.7.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "js-yaml": "^3.8.2",
-    "probot": "probot/probot",
-    "probot-visitor": "probot/visitor"
+    "probot": "^0.6",
+    "probot-visitor": "^0.2"
   },
   "engines": {
     "node": "^7.7",


### PR DESCRIPTION
This updates to the latest probot, using `context.github`, which was introduced in 0.5.0, and updating uses of the GitHub client to always look for `res.data` (cc https://github.com/mikedeboer/node-github/pull/505).

cc https://github.com/probot/probot/pull/153 for the next release of probot