### PR TITLE
More explicit node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "probot-visitor": "^0.1.1"
   },
   "engines": {
-    "node": ">= 7.7.0",
-    "npm": ">= 4.0.0"
+    "node": "^7.7",
+    "npm": "^4.0"
   },
   "devDependencies": {
     "eslint-config-probot": "^0.1.0",


### PR DESCRIPTION
Probot [currently specifies](https://github.com/probot/probot/blob/master/package.json):

```json
  "engines": {
    "node": "^7.7"
  }
```

Since 0.8 was released, deploys are currently broken, so updating this until a new release of probot is pushed out.