### PR TITLE
Wrap label in quotes in getClosableIssues

### DIFF
--- a/lib/stale.js
+++ b/lib/stale.js
@@ -29,7 +29,7 @@ module.exports = class Stale {
   }
 
   getClosableIssues() {
-    const query = `label:${this.config.staleLabel}`;
+    const query = `label:"${this.config.staleLabel}"`;
     const days = this.config.days || this.config.daysUntilClose;
     return this.search(days, query);
   }


### PR DESCRIPTION
This is related to #43 and #23. I believe the `getClosableIssues` function is failing for labels that contain spaces as they need to be wrapped in quotes to create a valid query.