### PR TITLE
Limit to 30 issues per run

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ The app uses GitHub's [updated](https://help.github.com/articles/searching-issue
 
 An easy way to check and see which issues or pull requests will initially be marked as stale is to add the `updated` search qualifier to either the issue or pull request page filter for your repository: `updated:<2017-07-01`. Adjust the date to be 60 days ago (or whatever you set for `daysUntilStale`) to see which issues or pull requests will be marked.
 
+## Why did only some issues and pull requests get marked stale?
+
+To avoid triggering abuse prevention mechanisms on GitHub, only 30 issues and pull requests will be marked or closed per hour. If your repository has more than that, it will just take a few hours or days to mark them all.
+
 ## Deployment
 
 See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this plugin.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ closeComment: false
 # only: issues
 ```
 
-## How are issues & pull requests considered stale?
+## How are issues and pull requests considered stale?
 
 The app uses GitHub's [updated](https://help.github.com/articles/searching-issues/#search-based-on-when-an-issue-or-pull-request-was-created-or-last-updated) search qualifier to determine staleness. Any change to an issues and pull request is considered an update, including comments, changing labels, applying or removing milestones,  or pushing commits.
 

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -10,14 +10,14 @@ module.exports = class Stale {
 
     await this.ensureStaleLabelExists()
 
-    this.github.paginate(this.getStaleIssues(), res => {
+    this.getStaleIssues().then(res => {
       res.data.items.filter(issue => !issue.locked)
-                .forEach(issue => this.mark(issue))
+        .forEach(issue => this.mark(issue))
     })
 
-    this.github.paginate(this.getClosableIssues(), res => {
+    this.getClosableIssues().then(res => {
       res.data.items.filter(issue => !issue.locked)
-                .forEach(issue => this.close(issue))
+        .forEach(issue => this.close(issue))
     })
   }
 
@@ -46,7 +46,7 @@ module.exports = class Stale {
       query += ` is:pr`
     }
 
-    const params = {q: query, sort: 'updated', order: 'desc', per_page: 100}
+    const params = {q: query, sort: 'updated', order: 'desc', per_page: 30}
 
     this.logger.debug(params, 'searching %s/%s for stale issues', owner, repo)
     return this.github.search.issues(params)


### PR DESCRIPTION
Repositories with a lot of open issues tend to trigger abuse mechanisms on GitHub. This limits it to 30 issues in an attempt to reduce errors. Repositories with more than 30 stale issues will have to wait for multiple runs (every hour) for all open issues to be marked.

Should fix #26 