### PR TITLE
Comment before labeling

### DIFF
--- a/lib/stale.js
+++ b/lib/stale.js
@@ -52,49 +52,48 @@ module.exports = class Stale {
     return this.github.search.issues(params)
   }
 
-  mark (issue) {
+  async mark (issue) {
     const {owner, repo, staleLabel, markComment, perform} = this.config
     const number = issue.number
 
     if (perform) {
       this.logger.info('%s/%s#%d is being marked', owner, repo, number)
-      return this.github.issues.addLabels({owner, repo, number, labels: [staleLabel]}).then(() => {
-        if (markComment) {
-          return this.github.issues.createComment({owner, repo, number, body: markComment})
-        }
-      })
+      if (markComment) {
+        await this.github.issues.createComment({owner, repo, number, body: markComment})
+      }
+      return this.github.issues.addLabels({owner, repo, number, labels: [staleLabel]})
     } else {
       this.logger.info('%s/%s#%d would have been marked (dry-run)', owner, repo, number)
     }
   }
 
-  close (issue) {
+  async close (issue) {
     const {owner, repo, perform, closeComment} = this.config
     const number = issue.number
 
     if (perform) {
       this.logger.info('%s/%s#%d is being closed', owner, repo, number)
-      return this.github.issues.edit({owner, repo, number, state: 'closed'}).then(() => {
-        if (closeComment) {
-          return this.github.issues.createComment({owner, repo, number, body: closeComment})
-        }
-      })
+      if (closeComment) {
+        await this.github.issues.createComment({owner, repo, number, body: closeComment})
+      }
+      return this.github.issues.edit({owner, repo, number, state: 'closed'})
     } else {
       this.logger.info('%s/%s#%d would have been closed (dry-run)', owner, repo, number)
     }
   }
 
-  unmark (issue) {
+  async unmark (issue) {
     const {owner, repo, perform, staleLabel, unmarkComment} = this.config
     const number = issue.number
 
     if (perform) {
       this.logger.info('%s/%s#%d is being unmarked', owner, repo, number)
-      return this.github.issues.removeLabel({owner, repo, number, name: staleLabel}).then(() => {
-        if (unmarkComment) {
-          return this.github.issues.createComment({owner, repo, number, body: unmarkComment})
-        }
-      })
+
+      if (unmarkComment) {
+        await this.github.issues.createComment({owner, repo, number, body: unmarkComment})
+      }
+
+      return this.github.issues.removeLabel({owner, repo, number, name: staleLabel})
     } else {
       this.logger.info('%s/%s#%d would have been unmarked (dry-run)', owner, repo, number)
     }


### PR DESCRIPTION
In case the app still triggers the abuse detection (https://github.com/probot/stale/issues/26), this ensures that it tries the abusive activity (commenting) first, and then follows up the non-abusive activity (label).