### PR TITLE
Allow different settings for pulls and issues. Add config 'limitPerRun'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,21 @@ markComment: >
 unmarkComment: false
 # Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
 closeComment: false
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
 # Limit to only `issues` or `pulls`
 # only: issues
+#
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+# issues:
+#   exemptLabels:
+#     - confirmed
 ```
 
 ## How are issues and pull requests considered stale?

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports = async robot => {
     if (!context.isBot) {
       const stale = await forRepository(context)
       let issue = context.payload.issue || context.payload.pull_request
+      const type = context.payload.issue ? 'issues' : 'pulls'
 
       // Some payloads don't include labels
       if (!issue.labels) {
@@ -30,17 +31,16 @@ module.exports = async robot => {
       const staleLabelAdded = context.payload.action === 'labeled' &&
         context.payload.label.name === stale.config.staleLabel
 
-      if (stale.hasStaleLabel(issue) && issue.state !== 'closed' && !staleLabelAdded) {
-        stale.unmark(issue)
+      if (stale.hasStaleLabel(type, issue) && issue.state !== 'closed' && !staleLabelAdded) {
+        stale.unmark(type, issue)
       }
     }
   }
 
   async function markAndSweep (context) {
     const stale = await forRepository(context)
-    if (stale.config.perform) {
-      return stale.markAndSweep()
-    }
+    await stale.markAndSweep('pulls')
+    await stale.markAndSweep('issues')
   }
 
   async function forRepository (context) {

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -1,59 +1,90 @@
+const maxActionsPerRun = 30
+
 module.exports = class Stale {
   constructor (github, config = {}) {
     this.github = github
     this.config = Object.assign({}, require('./defaults'), config || {})
     this.logger = config.logger || console
+    this.remainingActions = 0
   }
 
-  async markAndSweep () {
-    this.logger.trace(this.config, 'starting mark and sweep')
+  async markAndSweep (type) {
+    const only = this.config.only
+    if (only && only !== type) {
+      return
+    }
+    if (!this.getConfigValue(type, 'perform')) {
+      return
+    }
 
-    await this.ensureStaleLabelExists()
+    this.logger.info(this.config, `starting mark and sweep of ${type}`)
 
-    this.getStaleIssues().then(res => {
+    const limitPerRun = this.getConfigValue(type, 'limitPerRun') || maxActionsPerRun
+    this.remainingActions = Math.min(limitPerRun, maxActionsPerRun)
+
+    await this.ensureStaleLabelExists(type)
+
+    this.getStale(type).then(res => {
       res.data.items.filter(issue => !issue.locked)
-        .forEach(issue => this.mark(issue))
+        .forEach(issue => this.mark(type, issue))
     })
 
-    this.getClosableIssues().then(res => {
+    this.getClosable(type).then(res => {
       res.data.items.filter(issue => !issue.locked)
-        .forEach(issue => this.close(issue))
+        .forEach(issue => this.close(type, issue))
     })
   }
 
-  getStaleIssues () {
-    const labels = [this.config.staleLabel].concat(this.config.exemptLabels)
-    const query = labels.map(label => `-label:"${label}"`).join(' ')
-    const days = this.config.days || this.config.daysUntilStale
-    return this.search(days, query)
+  getStale (type) {
+    const staleLabel = this.getConfigValue(type, 'staleLabel')
+    const exemptLabels = this.getConfigValue(type, 'exemptLabels')
+    const labels = [staleLabel].concat(exemptLabels)
+    const queryParts = labels.map(label => `-label:"${label}"`)
+    queryParts.push(Stale.getQueryTypeRestriction(type))
+    const query = queryParts.join(' ')
+    const days = this.getConfigValue(type, 'days') || this.getConfigValue(type, 'daysUntilStale')
+    return this.search(type, days, query)
   }
 
-  getClosableIssues () {
-    const query = `label:"${this.config.staleLabel}"`
-    const days = this.config.days || this.config.daysUntilClose
-    return this.search(days, query)
+  getClosable (type) {
+    const staleLabel = this.getConfigValue(type, 'staleLabel')
+    const queryTypeRestriction = Stale.getQueryTypeRestriction(type)
+    const query = `label:"${staleLabel}" ${queryTypeRestriction}`
+    const days = this.getConfigValue(type, 'days') || this.getConfigValue(type, 'daysUntilClose')
+    return this.search(type, days, query)
   }
 
-  search (days, query) {
-    const {owner, repo, only} = this.config
+  static getQueryTypeRestriction (type) {
+    if (type === 'pulls') {
+      return 'is:pr'
+    } else if (type === 'issues') {
+      return 'is:issue'
+    }
+    throw new Error(`Unknown type: ${type}. Valid types are 'pulls' and 'issues'`)
+  }
+
+  search (type, days, query) {
+    const {owner, repo} = this.config
     const timestamp = this.since(days).toISOString().replace(/\.\d{3}\w$/, '')
 
     query = `repo:${owner}/${repo} is:open updated:<${timestamp} ${query}`
 
-    if (only === 'issues') {
-      query += ` is:issue`
-    } else if (only === 'pulls') {
-      query += ` is:pr`
-    }
+    const params = {q: query, sort: 'updated', order: 'desc', per_page: maxActionsPerRun}
 
-    const params = {q: query, sort: 'updated', order: 'desc', per_page: 30}
-
-    this.logger.debug(params, 'searching %s/%s for stale issues', owner, repo)
+    this.logger.info(params, 'searching %s/%s for stale issues', owner, repo)
     return this.github.search.issues(params)
   }
 
-  async mark (issue) {
-    const {owner, repo, staleLabel, markComment, perform} = this.config
+  async mark (type, issue) {
+    if (this.remainingActions === 0) {
+      return
+    }
+    this.remainingActions--
+
+    const {owner, repo} = this.config
+    const perform = this.getConfigValue(type, 'perform')
+    const staleLabel = this.getConfigValue(type, 'staleLabel')
+    const markComment = this.getConfigValue(type, 'markComment')
     const number = issue.number
 
     if (perform) {
@@ -67,8 +98,15 @@ module.exports = class Stale {
     }
   }
 
-  async close (issue) {
-    const {owner, repo, perform, closeComment} = this.config
+  async close (type, issue) {
+    if (this.remainingActions === 0) {
+      return
+    }
+    this.remainingActions--
+
+    const {owner, repo} = this.config
+    const perform = this.getConfigValue(type, 'perform')
+    const closeComment = this.getConfigValue(type, 'closeComment')
     const number = issue.number
 
     if (perform) {
@@ -82,8 +120,11 @@ module.exports = class Stale {
     }
   }
 
-  async unmark (issue) {
-    const {owner, repo, perform, staleLabel, unmarkComment} = this.config
+  async unmark (type, issue) {
+    const {owner, repo} = this.config
+    const perform = this.getConfigValue(type, 'perform')
+    const staleLabel = this.getConfigValue(type, 'staleLabel')
+    const unmarkComment = this.getConfigValue(type, 'unmarkComment')
     const number = issue.number
 
     if (perform) {
@@ -105,16 +146,27 @@ module.exports = class Stale {
   }
 
   // Returns true if at least one exempt label is present.
-  hasExemptLabel (issue) {
-    return issue.labels.some(label => this.config.exemptLabels.includes(label.name))
+  hasExemptLabel (type, issue) {
+    const exemptLabels = this.getConfigValue(type, 'exemptLabels')
+    return issue.labels.some(label => exemptLabels.includes(label.name))
   }
 
-  hasStaleLabel (issue) {
-    return issue.labels.map(label => label.name).includes(this.config.staleLabel)
+  hasStaleLabel (type, issue) {
+    const staleLabel = this.getConfigValue(type, 'staleLabel')
+    return issue.labels.map(label => label.name).includes(staleLabel)
   }
 
-  async ensureStaleLabelExists () {
-    const {owner, repo, staleLabel} = this.config
+  // returns a type-specific config value if it exists, otherwise returns the top-level value.
+  getConfigValue (type, key) {
+    if (this.config[type] && typeof this.config[type][key] !== 'undefined') {
+      return this.config[type][key]
+    }
+    return this.config[key]
+  }
+
+  async ensureStaleLabelExists (type) {
+    const {owner, repo} = this.config
+    const staleLabel = this.getConfigValue(type, 'staleLabel')
 
     return this.github.issues.getLabel({owner, repo, name: staleLabel}).catch(() => {
       return this.github.issues.createLabel({owner, repo, name: staleLabel, color: 'ffffff'})

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -14,6 +14,8 @@ describe('stale', () => {
   beforeEach(() => {
     robot = createRobot()
 
+    const issueAction = expect.createSpy().andReturn(Promise.resolve(notFoundError))
+
     // Mock out the GitHub API
     github = {
       integrations: {
@@ -21,7 +23,15 @@ describe('stale', () => {
       },
       paginate: expect.createSpy(),
       issues: {
-        removeLabel: expect.createSpy().andReturn(Promise.reject(notFoundError))
+        removeLabel: issueAction,
+        getLabel: expect.createSpy().andReturn(Promise.reject(notFoundError)),
+        createLabel: issueAction,
+        addLabels: issueAction,
+        createComment: issueAction,
+        edit: issueAction
+      },
+      search: {
+        issues: issueAction
       }
     }
 
@@ -32,10 +42,88 @@ describe('stale', () => {
   it('removes the stale label and ignores if it has already been removed', async () => {
     let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale'})
 
-    try {
-      await stale.unmark({number: 123})
-    } catch (_) {
-      throw new Error('Should not have thrown an error')
+    for (const type of ['pulls', 'issues']) {
+      try {
+        await stale.unmark(type, {number: 123})
+      } catch (_) {
+        throw new Error('Should not have thrown an error')
+      }
+    }
+  })
+
+  it('should limit the number of actions it takes each run', async () => {
+    const staleLabel = 'stale'
+    const limitPerRun = 30
+
+    const issueCount = 40
+    const staleCount = 3
+
+    const issues = []
+    for (let i = 1; i <= issueCount; i++) {
+      const labels = (i <= staleCount) ? [{name: staleLabel}] : []
+      issues.push({number: i, labels: labels})
+    }
+
+    const prs = []
+    for (let i = 101; i <= 100 + issueCount; i++) {
+      const labels = (i <= 100 + staleCount) ? [{name: staleLabel}] : []
+      prs.push({number: i, labels: labels})
+    }
+
+    github.search.issues = ({q, sort, order, per_page}) => {
+      let items = []
+      if (q.includes('is:pr')) {
+        items = items.concat(prs.slice(0, per_page))
+      } else if (q.includes('is:issue')) {
+        items = items.concat(issues.slice(0, per_page))
+      } else {
+        throw new Error('query should specify PullRequests or Issues')
+      }
+
+      if (q.includes(`-label:"${staleLabel}"`)) {
+        items = items.filter(item => !item.labels.map(label => label.name).includes(staleLabel))
+      } else if (q.includes(`label:"${staleLabel}"`)) {
+        items = items.filter(item => item.labels.map(label => label.name).includes(staleLabel))
+      }
+
+      expect(items.length).toBeLessThanOrEqualTo(per_page)
+
+      return Promise.resolve({
+        data: {
+          items: items
+        }
+      })
+    }
+
+    for (const type of ['pulls', 'issues']) {
+      let comments = 0
+      let closed = 0
+      let labeledStale = 0
+      github.issues.createComment = expect.createSpy().andCall(() => comments++).andReturn(Promise.resolve(notFoundError))
+      github.issues.edit = ({owner, repo, number, state}) => {
+        if (state === 'closed') {
+          closed++
+        }
+      }
+      github.issues.addLabels = ({owner, repo, number, labels}) => {
+        if (labels.includes(staleLabel)) {
+          labeledStale++
+        }
+      }
+
+      // Mock out GitHub client
+      robot.auth = () => Promise.resolve(github)
+
+      const stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale'})
+      stale.config.limitPerRun = limitPerRun
+      stale.config.staleLabel = staleLabel
+      stale.config.closeComment = 'closed'
+
+      await stale.markAndSweep(type)
+
+      expect(comments).toEqual(limitPerRun)
+      expect(closed).toEqual(staleCount)
+      expect(labeledStale).toEqual(limitPerRun - staleCount)
     }
   })
 })


### PR DESCRIPTION
Hello, and thanks for the useful bot! 
You recommended I make a PR, and I hope this makes the bot even better.

This PR does two things:
* Closes #66: Feature Request: different stale settings for PRs and Issues
   * Most configs can be specified for just 'pulls' or 'issues' as overrides for the 'global' config values.
   * The config values for `owner`, `repo`, `only`, and `logger` all remain 'global' only.
* Add config 'limitPerRun'
   * Limit per run is still capped at 30, but the config can now set it lower.
   * This will let me start chipping away at old issues at 1 per hour instead of getting a huge flood.

This should all be backward compatible, and examples for the new configs are added to the `README`.

~Unfortunately I was not able to easily find a way to test this out.~
~I have looked it over as carefully as I can, but if you can test it out or point me in the right direction I would really appreciate it!~