### PR TITLE
On unmark, ignore if stale label has already been removed

### DIFF
--- a/lib/stale.js
+++ b/lib/stale.js
@@ -93,7 +93,12 @@ module.exports = class Stale {
         await this.github.issues.createComment({owner, repo, number, body: unmarkComment})
       }
 
-      return this.github.issues.removeLabel({owner, repo, number, name: staleLabel})
+      return this.github.issues.removeLabel({owner, repo, number, name: staleLabel}).catch((err) => {
+        // ignore if it's a 404 because then the label was already removed
+        if (err.code !== 404) {
+          throw err
+        }
+      })
     } else {
       this.logger.info('%s/%s#%d would have been unmarked (dry-run)', owner, repo, number)
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/probot/stale",
   "scripts": {
     "start": "probot run ./index.js",
-    "test": "standard"
+    "test": "jest && standard"
   },
   "dependencies": {
     "probot": "^3.0.0",
@@ -22,5 +22,16 @@
     "expect": "^1.20.2",
     "localtunnel": "^1.8.3",
     "mocha": "^3.5.0"
+  },
+  "jest": {
+    "testMatch": [ "**/test/**/*.js?(x)", "**/?(*.)(spec|test).js?(x)" ],
+    "modulePathIgnorePatterns": [
+      "<rootDir>/test/fixtures/"
+    ]
+  },
+  "standard": {
+    "env": [
+      "jest"
+    ]
   }
 }

--- a/test/stale.js
+++ b/test/stale.js
@@ -1,0 +1,41 @@
+const expect = require('expect')
+const {createRobot} = require('probot')
+const Stale = require('../lib/stale')
+const notFoundError = {
+  code: 404,
+  status: 'Not Found',
+  headers: {}
+}
+
+describe('stale', () => {
+  let robot
+  let github
+
+  beforeEach(() => {
+    robot = createRobot()
+
+    // Mock out the GitHub API
+    github = {
+      integrations: {
+        getInstallations: expect.createSpy()
+      },
+      paginate: expect.createSpy(),
+      issues: {
+        removeLabel: expect.createSpy().andReturn(Promise.reject(notFoundError))
+      }
+    }
+
+    // Mock out GitHub client
+    robot.auth = () => Promise.resolve(github)
+  })
+
+  it('removes the stale label and ignores if it has already been removed', async () => {
+    let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale'})
+
+    try {
+      await stale.unmark({number: 123})
+    } catch (_) {
+      throw new Error('Should not have thrown an error')
+    }
+  })
+})


### PR DESCRIPTION
Hi,
this catches any 404 error thrown by the GitHub-API when the client tries to remove a label which no longer exists on the specific issue / PR (described in #52 by @bkeepers ). I also added a test file and tried to make it similar to tests from other repos within the probot organization.