### PR TITLE
Get Travis running & tests passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+  - "7.7.1"
+notifications:
+  disabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "7.7.1"
+  - 8
 notifications:
   disabled: true

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/probot/stale",
   "scripts": {
     "start": "probot run ./index.js",
-    "test": "jest && standard"
+    "test": "mocha && standard"
   },
   "dependencies": {
     "probot": "^3.0.0",


### PR DESCRIPTION
Noticed while helping @tcbyrd out with #84 that `mocha` is the dependency in the tests, but `jest` was being used to run the tests.

We can migrate to jest in a separate PR, but this should get the tests running on Travis.