### PR TITLE
Setup guards for config options

### DIFF
--- a/lib/stale.js
+++ b/lib/stale.js
@@ -13,7 +13,7 @@ const checkConfig = (config) => {
 
   if (daysUntilStale) {
     if (daysUntilStale < MIN || daysUntilStale > MAX) {
-      throw new RangeError({owner, repo}, `daysUntilStale must be between ${MIN} and ${MAX}: (daysUntilStale=${daysUntilStale})`)
+      throw new RangeError(`daysUntilStale must be between ${MIN} and ${MAX}: (daysUntilStale=${daysUntilStale})`)
     }
   }
 

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -1,25 +1,25 @@
 const maxActionsPerRun = 30
 
 const checkConfig = (config) => {
+  const {daysUntilClose, daysUntilStale, staleLabel} = config
   const MIN = 1
   const MAX = 10000
 
-  if (config.daysUntilClose) {
-    if (config.daysUntilClose < MIN || config.daysUntilClose > MAX) {
-      throw new RangeError(`daysUntilClose must be between ${MIN} and ${MAX}`)
+  if (daysUntilClose) {
+    if (daysUntilClose < MIN || daysUntilClose > MAX) {
+      throw new RangeError(`daysUntilClose must be between ${MIN} and ${MAX}: (daysUntilClose=${daysUntilClose})`)
     }
   }
 
-  if (config.daysUntilStale) {
-    if (config.daysUntilStale < MIN || config.daysUntilStale > MAX) {
-      throw new RangeError(`daysUntilStale must be between ${MIN} and ${MAX}`)
+  if (daysUntilStale) {
+    if (daysUntilStale < MIN || daysUntilStale > MAX) {
+      throw new RangeError({owner, repo}, `daysUntilStale must be between ${MIN} and ${MAX}: (daysUntilStale=${daysUntilStale})`)
     }
   }
 
-  if (typeof config.staleLabel !== 'string') {
-    throw new TypeError(`staleLabel must be a string. Received ${typeof config.staleLabel}: ${config.staleLabel}`)
+  if (typeof staleLabel !== 'string') {
+    throw new TypeError(`staleLabel must be a string: (staleLabel=${staleLabel} [${typeof staleLabel}])`)
   }
-  
 }
 
 module.exports = class Stale {
@@ -62,7 +62,6 @@ module.exports = class Stale {
     } else {
       this.logger.trace({owner, repo}, 'Configured to leave stale issues open')
     }
-
   }
 
   getStale (type) {

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -1,9 +1,32 @@
 const maxActionsPerRun = 30
 
+const checkConfig = (config) => {
+  const MIN = 1
+  const MAX = 10000
+
+  if (config.daysUntilClose) {
+    if (config.daysUntilClose < MIN || config.daysUntilClose > MAX) {
+      throw new RangeError(`daysUntilClose must be between ${MIN} and ${MAX}`)
+    }
+  }
+
+  if (config.daysUntilStale) {
+    if (config.daysUntilStale < MIN || config.daysUntilStale > MAX) {
+      throw new RangeError(`daysUntilStale must be between ${MIN} and ${MAX}`)
+    }
+  }
+
+  if (typeof config.staleLabel !== 'string') {
+    throw new TypeError(`staleLabel must be a string. Received ${typeof config.staleLabel}: ${config.staleLabel}`)
+  }
+  
+}
+
 module.exports = class Stale {
   constructor (github, config = {}) {
     this.github = github
     this.config = Object.assign({}, require('./defaults'), config || {})
+    checkConfig(this.config)
     this.logger = config.logger || console
     this.remainingActions = 0
   }


### PR DESCRIPTION
Closes #81 

I wasn't sure what the most optimal way to do this was, but here's what I came up with. If we check the config in the constructor and throw the appropriate errors, it won't attempt any further action on the offending repository until the next scheduled `markAndSweep`. We still need a way to report this error to the user, but this at least handles the error more gracefully and lets us know the problem was caused by an invalid configuration.

Here is an example error message:

```log
00:12:05.784Z ERROR probot: daysUntilClose must be between 1 and 10000: (daysUntilClose=10005)
  RangeError: daysUntilClose must be between 1 and 10000: (daysUntilClose=10005)
      at checkConfig (/Users/tcbyrd/probot/stale/lib/stale.js:10:13)
      at new Stale (/Users/tcbyrd/probot/stale/lib/stale.js:30:5)
      at forRepository (/Users/tcbyrd/probot/stale/index.js:57:12)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:160:7)
  --
  event: {
    "event": "schedule.repository",
    "repository": "tcbyrd/testrepo",
    "installation": 32078
  }
```