### PR TITLE
Add ability to ignore issues in a Project or Milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ exemptLabels:
   - pinned
   - security
   - "[Status] Maybe Later"
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
 # Label to use when marking as stale
 staleLabel: wontfix
 # Comment to post when marking as stale. Set to `false` to disable

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ exemptLabels:
   - security
   - "[Status] Maybe Later"
 # Set to true to ignore issues in a project (defaults to false)
-exemptProjects: true
+exemptProjects: false
 # Set to true to ignore issues in a milestone (defaults to false)
-exemptMilestones: true
+exemptMilestones: false
 # Label to use when marking as stale
 staleLabel: wontfix
 # Comment to post when marking as stale. Set to `false` to disable

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -2,6 +2,8 @@ module.exports = {
   daysUntilStale: 60,
   daysUntilClose: 7,
   exemptLabels: ['pinned', 'security'],
+  exemptProjects: false,
+  exemptMilestones: false,
   staleLabel: 'wontfix',
   perform: !process.env.DRY_RUN,
   markComment: 'This issue has been automatically marked as stale because ' +

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -44,9 +44,15 @@ module.exports = class Stale {
   getStale (type) {
     const staleLabel = this.getConfigValue(type, 'staleLabel')
     const exemptLabels = this.getConfigValue(type, 'exemptLabels')
+    const exemptProjects = this.getConfigValue(type, 'exemptProjects')
+    const exemptMilestones = this.getConfigValue(type, 'exemptMilestones')
     const labels = [staleLabel].concat(exemptLabels)
     const queryParts = labels.map(label => `-label:"${label}"`)
     queryParts.push(Stale.getQueryTypeRestriction(type))
+
+    queryParts.push(exemptProjects ? 'no:project' : '')
+    queryParts.push(exemptMilestones ? 'no:milestone' : '')
+
     const query = queryParts.join(' ')
     const days = this.getConfigValue(type, 'days') || this.getConfigValue(type, 'daysUntilStale')
     return this.search(type, days, query)


### PR DESCRIPTION
This PR adds the ability to ignore issues assigned to a project or milestone without needing to look for a specific label.