### PR TITLE
Fix dates before 1970

### DIFF
--- a/lib/stale.js
+++ b/lib/stale.js
@@ -187,6 +187,12 @@ module.exports = class Stale {
 
   since (days) {
     const ttl = days * 24 * 60 * 60 * 1000
-    return new Date(new Date() - ttl)
+    let date = new Date(new Date() - ttl)
+
+    // GitHub won't allow it
+    if (date < new Date(0)) {
+      date = new Date(0)
+    }
+    return date
   }
 }


### PR DESCRIPTION
If someone sets a very large value in `daysUntilStale` or `daysUntilClose`, GitHub will return an error:

`{"message":"Validation Failed","errors":[{"message":"The year 1744 in \"1744-04-29T04:07:36\" is outside the accepted range 1970 to 2970.","resource":"Search","field":"q","code":"invalid"}],"documentation_url":"https://developer.github.com/v3/search/"}`

This is a temporary work around to just set 1970 as the minimum date for any query.

#92 should include a long-term fix for this.