### PR TITLE
Fix bug where `pulls` and `issues` config get all defaults

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,62 +1,61 @@
 const Joi = require('joi')
 
-const options = {
-  daysUntilStale: Joi.number().default(60)
+const fields = {
+  daysUntilStale: Joi.number()
     .description('Number of days of inactivity before an Issue or Pull Request becomes stale'),
 
   daysUntilClose: Joi.alternatives().try(Joi.number(), Joi.boolean().only(false))
-    .default(7)
     .error(() => '"daysUntilClose" must be a number or false')
     .description('Number of days of inactivity before a stale Issue or Pull Request is closed. If disabled, issues still need to be closed manually, but will remain marked as stale.'),
 
   exemptLabels: Joi.alternatives().try(Joi.any().valid(null), Joi.array().single())
-    .default(['pinned', 'security'])
     .description('Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable'),
 
-  exemptProjects: Joi.boolean().default(false)
+  exemptProjects: Joi.boolean()
     .description('Set to true to ignore issues in a project (defaults to false)'),
 
-  exemptMilestones: Joi.boolean().default(false)
+  exemptMilestones: Joi.boolean()
     .description('Set to true to ignore issues in a milestone (defaults to false)'),
 
-  staleLabel: Joi.string().default('wontfix')
+  staleLabel: Joi.string()
     .description('Label to use when marking as stale'),
 
   markComment: Joi.alternatives().try(Joi.string(), Joi.any().only(false))
-    .default(
-      'This issue has been automatically marked as stale because ' +
-      'it has not had recent activity. It will be closed if no further ' +
-      'activity occurs. Thank you for your contributions.'
-    )
     .error(() => '"markComment" must be a string or false')
     .description('Comment to post when marking as stale. Set to `false` to disable'),
 
   unmarkComment: Joi.alternatives().try(Joi.string(), Joi.boolean().only(false))
-    .default(false)
     .error(() => '"unmarkComment" must be a string or false')
     .description('Comment to post when removing the stale label. Set to `false` to disable'),
 
   closeComment: Joi.alternatives().try(Joi.string(), Joi.boolean().only(false))
-    .default(false)
     .error(() => '"closeComment" must be a string or false')
     .description('Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable'),
 
-  limitPerRun: Joi.number().integer().default(30).min(1).max(30)
+  limitPerRun: Joi.number().integer().min(1).max(30)
     .error(() => '"limitPerRun" must be an integer between 1 and 30')
     .description('Limit the number of actions per hour, from 1-30. Default is 30')
 }
 
 const schema = Joi.object().keys({
-  ...options,
-
+  daysUntilStale: fields.daysUntilStale.default(60),
+  daysUntilClose: fields.daysUntilClose.default(7),
+  exemptLabels: fields.exemptLabels.default(['pinned', 'security']),
+  exemptProjects: fields.exemptProjects.default(false),
+  exemptMilestones: fields.exemptMilestones.default(false),
+  staleLabel: fields.staleLabel.default('wontfix'),
+  markComment: fields.markComment.default(
+    'This issue has been automatically marked as stale because ' +
+    'it has not had recent activity. It will be closed if no further ' +
+    'activity occurs. Thank you for your contributions.'
+  ),
+  unmarkComment: fields.unmarkComment.default(false),
+  closeComment: fields.closeComment.default(false),
+  limitPerRun: fields.limitPerRun.default(30),
   perform: Joi.boolean().default(!process.env.DRY_RUN),
-
-  only: Joi.any().valid('issues', 'pulls', null)
-    .description('Limit to only `issues` or `pulls`'),
-
-  pulls: Joi.object().keys(options),
-
-  issues: Joi.object().keys(options)
+  only: Joi.any().valid('issues', 'pulls', null).description('Limit to only `issues` or `pulls`'),
+  pulls: Joi.object().keys(fields),
+  issues: Joi.object().keys(fields)
 })
 
 module.exports = schema

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -66,6 +66,16 @@ describe('schema', () => {
     })
   })
 
+  test('does not set defaults for pulls and issues', () => {
+    expect(schema.validate({pulls: {daysUntilStale: 90}}).value.pulls).toEqual({
+      daysUntilStale: 90
+    })
+
+    expect(schema.validate({issues: {daysUntilStale: 90}}).value.issues).toEqual({
+      daysUntilStale: 90
+    })
+  })
+
   validConfigs.forEach(([example, expected = example]) => {
     test(`${JSON.stringify(example)} is valid`, () => {
       const result = schema.validate(example)


### PR DESCRIPTION
#92 introduced a bug where as soon as you added one value to the `issues` or `pulls` options introduced in #69, then all other keys would get the default values, obscuring any top-level options.

To reproduce, use this config:

```yaml
daysUntilStale: 60
staleLabel: stale
issues:
  daysUntilStale: 90
```

Even though `issues` doesn't define `staleLabel`, it would get the default value (`wontfix`), obscuring the value set at the top level.

Fixes #95 
cc @mezz 