### PR TITLE
Use probot-config to allow inheriting config from another repo

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,1 @@
+_extends: .github

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const getConfig = require('probot-config')
 const createScheduler = require('probot-scheduler')
 const Stale = require('./lib/stale')
 
@@ -48,7 +49,7 @@ module.exports = async robot => {
   }
 
   async function forRepository (context) {
-    let config = await context.config('stale.yml')
+    let config = await getConfig(context, 'stale.yml')
 
     if (!config) {
       scheduler.stop(context.payload.repository)

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -55,7 +55,8 @@ const schema = Joi.object().keys({
   perform: Joi.boolean().default(!process.env.DRY_RUN),
   only: Joi.any().valid('issues', 'pulls', null).description('Limit to only `issues` or `pulls`'),
   pulls: Joi.object().keys(fields),
-  issues: Joi.object().keys(fields)
+  issues: Joi.object().keys(fields),
+  _extends: Joi.string().description('Repository to extend settings from')
 })
 
 module.exports = schema

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "joi": "^13.1.2",
     "probot": "^6.0.0",
+    "probot-config": "^0.1.0",
     "probot-scheduler": "^1.0.2",
     "standard": "^10.0.3"
   },

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -24,7 +24,9 @@ const validConfigs = [
   [{only: 'issues'}],
   [{only: 'pulls'}],
   [{pulls: {daysUntilStale: 2}}],
-  [{issues: {staleLabel: 'stale-issue'}}]
+  [{issues: {staleLabel: 'stale-issue'}}],
+  [{_extends: '.github'}],
+  [{_extends: 'foobar'}]
 ]
 
 const invalidConfigs = [
@@ -43,8 +45,9 @@ const invalidConfigs = [
   [{only: 'donuts'}, 'must be one of [issues, pulls, null]'],
   [{pulls: {daysUntilStale: 'no'}}, 'must be a number'],
   [{pulls: {lol: 'nope'}}, '"lol" is not allowed'],
-  [{issues: {staleLabel: ''}}, 'not allowed to be empty']
-
+  [{issues: {staleLabel: ''}}, 'not allowed to be empty'],
+  [{_extends: true}, 'must be a string'],
+  [{_extends: false}, 'must be a string']
 ]
 
 describe('schema', () => {


### PR DESCRIPTION
The `probot-config` package has a nice feature where it allows you to inherit configuration from another repository:

```
_extends: .github
daysUntilStale: 90
```

I'm going to start experimenting with this pattern and see about making it a feature of the built-in `context.config(…)` method.