### PR TITLE
Fix so daysUntilClose keyword can be used under the pulls or issues keyword

### DIFF
--- a/lib/stale.js
+++ b/lib/stale.js
@@ -39,7 +39,9 @@ module.exports = class Stale {
         .forEach(issue => this.mark(type, issue))
     })
 
-    const {daysUntilClose, owner, repo} = this.config
+    const {owner, repo} = this.config
+    const daysUntilClose = this.getConfigValue(type, 'daysUntilClose')
+
     if (daysUntilClose) {
       this.logger.trace({owner, repo}, 'Configured to close stale issues')
       this.getClosable(type).then(res => {

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -150,4 +150,21 @@ describe('stale', () => {
       expect(stale.getClosable).not.toHaveBeenCalled()
     }
   )
+
+  test(
+    'should not close issues if under keyword pulls is used with daysUntilClose is configured as false',
+    async () => {
+      let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale', logger: robot.log})
+      stale.config.pulls = { daysUntilClose: false }
+      stale.config.issues = { daysUntilClose: false }
+      stale.getStale = jest.fn().mockImplementation(() => Promise.resolve({data: {items: []}}))
+      stale.getClosable = jest.fn()
+
+      await stale.markAndSweep('issues')
+      expect(stale.getClosable).not.toHaveBeenCalled()
+
+      await stale.markAndSweep('pulls')
+      expect(stale.getClosable).not.toHaveBeenCalled()
+    }
+  )
 })

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -152,7 +152,7 @@ describe('stale', () => {
   )
 
   test(
-    'should not close issues if under keyword pulls is used with daysUntilClose is configured as false',
+    'should not close issues if the keyword pulls or keyword issues is used, and daysUntilClose is configured as false',
     async () => {
       let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale', logger: robot.log})
       stale.config.pulls = { daysUntilClose: false }

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -167,4 +167,32 @@ describe('stale', () => {
       expect(stale.getClosable).not.toHaveBeenCalled()
     }
   )
+
+  test(
+    'should not close issues if only keyword is configured with the pulls value',
+    async () => {
+      let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale', logger: robot.log})
+      stale.config.only = 'pulls'
+      stale.config.daysUntilClose = 1
+      stale.getStale = jest.fn().mockImplementation(() => Promise.resolve({data: {items: []}}))
+      stale.getClosable = jest.fn()
+
+      await stale.markAndSweep('issues')
+      expect(stale.getClosable).not.toHaveBeenCalled()
+    }
+  )
+
+  test(
+    'should not close pull requests if only keyword is configured with the issues value',
+    async () => {
+      let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale', logger: robot.log})
+      stale.config.only = 'issues'
+      stale.config.daysUntilClose = 1
+      stale.getStale = jest.fn().mockImplementation(() => Promise.resolve({data: {items: []}}))
+      stale.getClosable = jest.fn()
+
+      await stale.markAndSweep('pulls')
+      expect(stale.getClosable).not.toHaveBeenCalled()
+    }
+  )
 })


### PR DESCRIPTION
- Tests 
  - Added regression tests for daysUntilClose keyword when using pulls or issues keyword
  - Added regression tests for only keyword when using pulls or issues keyword
- Fix so daysUntilClose can be used under the pulls or issues keyword
- Fix so only can be used under the pulls or issues keyword

Fixes #129