### PR TITLE
Add option to not count weekends for age

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ limitPerRun: 30
 # issues:
 #   exemptLabels:
 #     - confirmed
+
+# Optionally, skip weekends when counting the age of an issue or pull. E.g. if it's Monday,
+# "one day old" would mean last updated on Friday. Default is false.
+skipWeekends: true
 ```
 
 ## How are issues and pull requests considered stale?

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -34,7 +34,10 @@ const fields = {
 
   limitPerRun: Joi.number().integer().min(1).max(30)
     .error(() => '"limitPerRun" must be an integer between 1 and 30')
-    .description('Limit the number of actions per hour, from 1-30. Default is 30')
+    .description('Limit the number of actions per hour, from 1-30. Default is 30'),
+
+  skipWeekends: Joi.boolean()
+    .description('Set to true to only count age in weekdays (defaults to false)')
 }
 
 const schema = Joi.object().keys({
@@ -56,6 +59,7 @@ const schema = Joi.object().keys({
   only: Joi.any().valid('issues', 'pulls', null).description('Limit to only `issues` or `pulls`'),
   pulls: Joi.object().keys(fields),
   issues: Joi.object().keys(fields),
+  skipWeekends: fields.skipWeekends.default(false),
   _extends: Joi.string().description('Repository to extend settings from')
 })
 

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -198,8 +198,26 @@ module.exports = class Stale {
   }
 
   since (days) {
-    const ttl = days * 24 * 60 * 60 * 1000
-    let date = new Date(new Date() - ttl)
+    const daysInMilliseconds = 24 * 60 * 60 * 1000
+    let daysToCount = 0
+    let daysAgo = 0
+
+    const { skipWeekends } = this.config
+    if (skipWeekends) {
+      while (daysToCount < days) {
+        daysAgo++
+        const dayOfWeek = new Date(Date.now() - daysAgo * daysInMilliseconds).getDay()
+        if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+          daysToCount++
+        }
+      }
+    } else {
+      daysAgo = days
+    }
+
+    const ttl = daysAgo * daysInMilliseconds
+
+    let date = new Date(Date.now() - ttl)
 
     // GitHub won't allow it
     if (date < new Date(0)) {

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -199,6 +199,7 @@ module.exports = class Stale {
 
   since (days) {
     const daysInMilliseconds = 24 * 60 * 60 * 1000
+    const now = Date.now()
     let daysToCount = 0
     let daysAgo = 0
 
@@ -206,7 +207,7 @@ module.exports = class Stale {
     if (skipWeekends) {
       while (daysToCount < days) {
         daysAgo++
-        const dayOfWeek = new Date(Date.now() - daysAgo * daysInMilliseconds).getDay()
+        const dayOfWeek = new Date(now - daysAgo * daysInMilliseconds).getDay()
         if (dayOfWeek !== 0 && dayOfWeek !== 6) {
           daysToCount++
         }
@@ -217,7 +218,7 @@ module.exports = class Stale {
 
     const ttl = daysAgo * daysInMilliseconds
 
-    let date = new Date(Date.now() - ttl)
+    let date = new Date(now - ttl)
 
     // GitHub won't allow it
     if (date < new Date(0)) {

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -25,6 +25,7 @@ const validConfigs = [
   [{only: 'pulls'}],
   [{pulls: {daysUntilStale: 2}}],
   [{issues: {staleLabel: 'stale-issue'}}],
+  [{skipWeekends: true}],
   [{_extends: '.github'}],
   [{_extends: 'foobar'}]
 ]
@@ -65,7 +66,8 @@ describe('schema', () => {
         'activity occurs. Thank you for your contributions.',
       unmarkComment: false,
       closeComment: false,
-      limitPerRun: 30
+      limitPerRun: 30,
+      skipWeekends: false
     })
   })
 

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -195,4 +195,30 @@ describe('stale', () => {
       expect(stale.getClosable).not.toHaveBeenCalled()
     }
   )
+
+  test(
+    'should count weekends for age by default',
+    async () => {
+      let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale', logger: robot.log})
+      stale.config.skipWeekends = false
+      const now = Date.now()
+      Date.now = jest.genMockFunction().mockReturnValue(now)
+      const sinceDate = stale.since(7)
+      expect(sinceDate).toEqual(new Date(now - 7 * 24 * 60 * 60 * 1000))
+    }
+  )
+
+  test(
+    'should not count weekends for age when configured with skipWeekends',
+    async () => {
+      let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale', logger: robot.log})
+      stale.config.skipWeekends = true
+
+      const now = new Date(2018, 5, 18) // June 18, 2018, a Monday
+      Date.now = jest.genMockFunction().mockReturnValue(now)
+
+      const sinceDate = stale.since(1)
+      expect(sinceDate).toEqual(new Date(2018, 5, 15)) // June 15, 2018, the preceding Friday
+    }
+  )
 })


### PR DESCRIPTION
Changes how Stale.since() counts days to add an option to not count
weekends against the age of an issue. When skipWeekends is true, we'll
go backward in time only counting weekdays until we get to the age. When
skipWeekends is false (the default) we'll shortcut this and treat the
argument to since() as a literal number of days.

Fixes #130