### PR TITLE
Fix test suites and stale.js test

### DIFF
--- a/lib/stale.js
+++ b/lib/stale.js
@@ -34,20 +34,22 @@ module.exports = class Stale {
 
     await this.ensureStaleLabelExists(type)
 
-    this.getStale(type).then(res => {
-      res.data.items.filter(issue => !issue.locked)
-        .forEach(issue => this.mark(type, issue))
-    })
+    const staleItems = (await this.getStale(type)).data.items
+
+    await Promise.all(staleItems.filter(issue => !issue.locked).map(issue => {
+      return this.mark(type, issue)
+    }))
 
     const {owner, repo} = this.config
     const daysUntilClose = this.getConfigValue(type, 'daysUntilClose')
 
     if (daysUntilClose) {
       this.logger.trace({owner, repo}, 'Configured to close stale issues')
-      this.getClosable(type).then(res => {
-        res.data.items.filter(issue => !issue.locked)
-          .forEach(issue => this.close(type, issue))
-      })
+      const closableItems = (await this.getClosable(type)).data.items
+
+      await Promise.all(closableItems.filter(issue => !issue.locked).map(issue => {
+        this.close(type, issue)
+      }))
     } else {
       this.logger.trace({owner, repo}, 'Configured to leave stale issues open')
     }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "env": [
       "jest"
     ]
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -106,7 +106,7 @@ describe('stale', () => {
       let labeledStale = 0
       github.issues.createComment = jest.fn().mockImplementation(() => {
         comments++
-        Promise.resolve(notFoundError)
+        return Promise.resolve(notFoundError)
       })
       github.issues.edit = ({owner, repo, number, state}) => {
         if (state === 'closed') {

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -106,7 +106,7 @@ describe('stale', () => {
       let labeledStale = 0
       github.issues.createComment = jest.fn().mockImplementation(() => {
         comments++
-        return Promise.resolve(notFoundError)
+        Promise.resolve(notFoundError)
       })
       github.issues.edit = ({owner, repo, number, state}) => {
         if (state === 'closed') {


### PR DESCRIPTION
Fixes #151 

Setting `"testEnvironment":"node"` broke this test:
https://github.com/probot/stale/blob/11629d71c98ee95e7da1a30085c15dcd684a189d/test/stale.test.js#L59

It seemed that the `await` was returning early, and after some tinkering I think I figured the issue:
https://github.com/probot/stale/blob/11629d71c98ee95e7da1a30085c15dcd684a189d/test/stale.test.js#L109

removing the `return` fixed the problem, though to be honest I am quite new to this world of promises and node and am not entirely sure why ¯\\_(ツ)_/¯ 