### PR TITLE
Make default comment friendlier and actionable (fixes #67)

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -46,7 +46,10 @@ const schema = Joi.object().keys({
   staleLabel: fields.staleLabel.default('wontfix'),
   markComment: fields.markComment.default(
     'Is this still relevant? If so, what is blocking it? ' +
-    'Is there anything you can do to help move it forward?'
+    'Is there anything you can do to help move it forward?' +
+    '\n\nThis issue has been automatically marked as stale ' +
+    'because it has not had recent activity. ' +
+    'It will be closed if no further activity occurs.'
   ),
   unmarkComment: fields.unmarkComment.default(false),
   closeComment: fields.closeComment.default(false),

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -45,9 +45,8 @@ const schema = Joi.object().keys({
   exemptMilestones: fields.exemptMilestones.default(false),
   staleLabel: fields.staleLabel.default('wontfix'),
   markComment: fields.markComment.default(
-    'This issue has been automatically marked as stale because ' +
-    'it has not had recent activity. It will be closed if no further ' +
-    'activity occurs. Thank you for your contributions.'
+    'Is this still relevant? If so, what is blocking it? ' +
+    'Is there anything you can do to help move it forward?'
   ),
   unmarkComment: fields.unmarkComment.default(false),
   closeComment: fields.closeComment.default(false),

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -61,7 +61,10 @@ describe('schema', () => {
       staleLabel: 'wontfix',
       perform: true,
       markComment: 'Is this still relevant? If so, what is blocking it? ' +
-        'Is there anything you can do to help move it forward?',
+        'Is there anything you can do to help move it forward?' +
+        '\n\nThis issue has been automatically marked as stale ' +
+        'because it has not had recent activity. ' +
+        'It will be closed if no further activity occurs.',
       unmarkComment: false,
       closeComment: false,
       limitPerRun: 30

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -60,9 +60,8 @@ describe('schema', () => {
       exemptMilestones: false,
       staleLabel: 'wontfix',
       perform: true,
-      markComment: 'This issue has been automatically marked as stale because ' +
-        'it has not had recent activity. It will be closed if no further ' +
-        'activity occurs. Thank you for your contributions.',
+      markComment: 'Is this still relevant? If so, what is blocking it? ' +
+        'Is there anything you can do to help move it forward?',
       unmarkComment: false,
       closeComment: false,
       limitPerRun: 30


### PR DESCRIPTION
The default message posted by the bot is unnecessarily harsh and final-sounding, which has resulted in a lot of grief, summarized in #67.

Interestingly enough, even this repo decided against using the default message and has been using a friendlier and more constructive message for a while.

This change makes that message the default, so that other communities using this bot get a more positive experience out of the box.