### PR TITLE
chore(package): update standard to v12

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,10 +54,10 @@ module.exports = async app => {
     if (!config) {
       scheduler.stop(context.payload.repository)
       // Don't actually perform for repository without a config
-      config = {perform: false}
+      config = { perform: false }
     }
 
-    config = Object.assign(config, context.repo({logger: app.log}))
+    config = Object.assign(config, context.repo({ logger: app.log }))
 
     return new Stale(context.github, config)
   }

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -2,24 +2,24 @@ const schema = require('./schema')
 const maxActionsPerRun = 30
 
 module.exports = class Stale {
-  constructor (github, {owner, repo, logger = console, ...config}) {
+  constructor (github, { owner, repo, logger = console, ...config }) {
     this.github = github
     this.logger = logger
     this.remainingActions = 0
 
-    const {error, value} = schema.validate(config)
+    const { error, value } = schema.validate(config)
 
     this.config = value
     if (error) {
       // Report errors to sentry
-      logger.warn({err: new Error(error), owner, repo}, 'Invalid config')
+      logger.warn({ err: new Error(error), owner, repo }, 'Invalid config')
     }
 
-    Object.assign(this.config, {owner, repo})
+    Object.assign(this.config, { owner, repo })
   }
 
   async markAndSweep (type) {
-    const {only} = this.config
+    const { only } = this.config
     if (only && only !== type) {
       return
     }
@@ -40,18 +40,18 @@ module.exports = class Stale {
       return this.mark(type, issue)
     }))
 
-    const {owner, repo} = this.config
+    const { owner, repo } = this.config
     const daysUntilClose = this.getConfigValue(type, 'daysUntilClose')
 
     if (daysUntilClose) {
-      this.logger.trace({owner, repo}, 'Configured to close stale issues')
+      this.logger.trace({ owner, repo }, 'Configured to close stale issues')
       const closableItems = (await this.getClosable(type)).data.items
 
       await Promise.all(closableItems.filter(issue => !issue.locked).map(issue => {
         this.close(type, issue)
       }))
     } else {
-      this.logger.trace({owner, repo}, 'Configured to leave stale issues open')
+      this.logger.trace({ owner, repo }, 'Configured to leave stale issues open')
     }
   }
 
@@ -90,12 +90,12 @@ module.exports = class Stale {
   }
 
   search (type, days, query) {
-    const {owner, repo} = this.config
+    const { owner, repo } = this.config
     const timestamp = this.since(days).toISOString().replace(/\.\d{3}\w$/, '')
 
     query = `repo:${owner}/${repo} is:open updated:<${timestamp} ${query}`
 
-    const params = {q: query, sort: 'updated', order: 'desc', per_page: maxActionsPerRun}
+    const params = { q: query, sort: 'updated', order: 'desc', per_page: maxActionsPerRun }
 
     this.logger.info(params, 'searching %s/%s for stale issues', owner, repo)
     return this.github.search.issues(params)
@@ -107,7 +107,7 @@ module.exports = class Stale {
     }
     this.remainingActions--
 
-    const {owner, repo} = this.config
+    const { owner, repo } = this.config
     const perform = this.getConfigValue(type, 'perform')
     const staleLabel = this.getConfigValue(type, 'staleLabel')
     const markComment = this.getConfigValue(type, 'markComment')
@@ -116,9 +116,9 @@ module.exports = class Stale {
     if (perform) {
       this.logger.info('%s/%s#%d is being marked', owner, repo, number)
       if (markComment) {
-        await this.github.issues.createComment({owner, repo, number, body: markComment})
+        await this.github.issues.createComment({ owner, repo, number, body: markComment })
       }
-      return this.github.issues.addLabels({owner, repo, number, labels: [staleLabel]})
+      return this.github.issues.addLabels({ owner, repo, number, labels: [staleLabel] })
     } else {
       this.logger.info('%s/%s#%d would have been marked (dry-run)', owner, repo, number)
     }
@@ -130,7 +130,7 @@ module.exports = class Stale {
     }
     this.remainingActions--
 
-    const {owner, repo} = this.config
+    const { owner, repo } = this.config
     const perform = this.getConfigValue(type, 'perform')
     const closeComment = this.getConfigValue(type, 'closeComment')
     const number = issue.number
@@ -138,16 +138,16 @@ module.exports = class Stale {
     if (perform) {
       this.logger.info('%s/%s#%d is being closed', owner, repo, number)
       if (closeComment) {
-        await this.github.issues.createComment({owner, repo, number, body: closeComment})
+        await this.github.issues.createComment({ owner, repo, number, body: closeComment })
       }
-      return this.github.issues.edit({owner, repo, number, state: 'closed'})
+      return this.github.issues.edit({ owner, repo, number, state: 'closed' })
     } else {
       this.logger.info('%s/%s#%d would have been closed (dry-run)', owner, repo, number)
     }
   }
 
   async unmark (type, issue) {
-    const {owner, repo} = this.config
+    const { owner, repo } = this.config
     const perform = this.getConfigValue(type, 'perform')
     const staleLabel = this.getConfigValue(type, 'staleLabel')
     const unmarkComment = this.getConfigValue(type, 'unmarkComment')
@@ -157,10 +157,10 @@ module.exports = class Stale {
       this.logger.info('%s/%s#%d is being unmarked', owner, repo, number)
 
       if (unmarkComment) {
-        await this.github.issues.createComment({owner, repo, number, body: unmarkComment})
+        await this.github.issues.createComment({ owner, repo, number, body: unmarkComment })
       }
 
-      return this.github.issues.removeLabel({owner, repo, number, name: staleLabel}).catch((err) => {
+      return this.github.issues.removeLabel({ owner, repo, number, name: staleLabel }).catch((err) => {
         // ignore if it's a 404 because then the label was already removed
         if (err.code !== 404) {
           throw err
@@ -191,11 +191,11 @@ module.exports = class Stale {
   }
 
   async ensureStaleLabelExists (type) {
-    const {owner, repo} = this.config
+    const { owner, repo } = this.config
     const staleLabel = this.getConfigValue(type, 'staleLabel')
 
-    return this.github.issues.getLabel({owner, repo, name: staleLabel}).catch(() => {
-      return this.github.issues.createLabel({owner, repo, name: staleLabel, color: 'ffffff'})
+    return this.github.issues.getLabel({ owner, repo, name: staleLabel }).catch(() => {
+      return this.github.issues.createLabel({ owner, repo, name: staleLabel, color: 'ffffff' })
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "joi": "^13.1.2",
     "probot": "7.0.1",
     "probot-config": "^0.1.0",
-    "probot-scheduler": "^1.0.2",
-    "standard": "^11.0.0"
+    "probot-scheduler": "^1.0.2"
   },
   "engines": {
     "node": "^8.9",
@@ -29,7 +28,8 @@
   },
   "devDependencies": {
     "jest": "^22.2.2",
-    "smee-client": "^1.0.1"
+    "smee-client": "^1.0.1",
+    "standard": "^12.0.1"
   },
   "standard": {
     "env": [

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1,53 +1,53 @@
 const schema = require('../lib/schema')
 
 const validConfigs = [
-  [{daysUntilClose: false}],
-  [{daysUntilClose: 1}],
-  [{exemptLabels: ['foo']}],
-  [{exemptLabels: 'foo'}, {exemptLabels: ['foo']}],
-  [{exemptLabels: null}],
-  [{exemptLabels: []}],
-  [{exemptProjects: true}],
-  [{exemptProjects: false}],
-  [{exemptMilestones: true}],
-  [{exemptMilestones: false}],
-  [{staleLabel: 'stale'}],
-  [{markComment: 'stale yo'}],
-  [{markComment: false}],
-  [{unmarkComment: 'not stale'}],
-  [{unmarkComment: false}],
-  [{closeComment: 'closing yo'}],
-  [{closeComment: false}],
-  [{limitPerRun: 1}],
-  [{limitPerRun: 30}],
-  [{only: null}],
-  [{only: 'issues'}],
-  [{only: 'pulls'}],
-  [{pulls: {daysUntilStale: 2}}],
-  [{issues: {staleLabel: 'stale-issue'}}],
-  [{_extends: '.github'}],
-  [{_extends: 'foobar'}]
+  [{ daysUntilClose: false }],
+  [{ daysUntilClose: 1 }],
+  [{ exemptLabels: ['foo'] }],
+  [{ exemptLabels: 'foo' }, { exemptLabels: ['foo'] }],
+  [{ exemptLabels: null }],
+  [{ exemptLabels: [] }],
+  [{ exemptProjects: true }],
+  [{ exemptProjects: false }],
+  [{ exemptMilestones: true }],
+  [{ exemptMilestones: false }],
+  [{ staleLabel: 'stale' }],
+  [{ markComment: 'stale yo' }],
+  [{ markComment: false }],
+  [{ unmarkComment: 'not stale' }],
+  [{ unmarkComment: false }],
+  [{ closeComment: 'closing yo' }],
+  [{ closeComment: false }],
+  [{ limitPerRun: 1 }],
+  [{ limitPerRun: 30 }],
+  [{ only: null }],
+  [{ only: 'issues' }],
+  [{ only: 'pulls' }],
+  [{ pulls: { daysUntilStale: 2 } }],
+  [{ issues: { staleLabel: 'stale-issue' } }],
+  [{ _extends: '.github' }],
+  [{ _extends: 'foobar' }]
 ]
 
 const invalidConfigs = [
-  [{daysUntilClose: true}, 'must be a number or false'],
-  [{exemptProjects: 'nope'}, 'must be a boolean'],
-  [{exemptMilestones: 'nope'}, 'must be a boolean'],
-  [{staleLabel: ''}, 'not allowed to be empty'],
-  [{staleLabel: false}, 'must be a string'],
-  [{staleLabel: ['a', 'b']}, 'must be a string'],
-  [{markComment: true}, 'must be a string or false'],
-  [{unmarkComment: true}, 'must be a string or false'],
-  [{closeComment: true}, 'must be a string or false'],
-  [{limitPerRun: 31}, 'must be an integer between 1 and 30'],
-  [{limitPerRun: 0}, 'must be an integer between 1 and 30'],
-  [{limitPerRun: 0.5}, 'must be an integer between 1 and 30'],
-  [{only: 'donuts'}, 'must be one of [issues, pulls, null]'],
-  [{pulls: {daysUntilStale: 'no'}}, 'must be a number'],
-  [{pulls: {lol: 'nope'}}, '"lol" is not allowed'],
-  [{issues: {staleLabel: ''}}, 'not allowed to be empty'],
-  [{_extends: true}, 'must be a string'],
-  [{_extends: false}, 'must be a string']
+  [{ daysUntilClose: true }, 'must be a number or false'],
+  [{ exemptProjects: 'nope' }, 'must be a boolean'],
+  [{ exemptMilestones: 'nope' }, 'must be a boolean'],
+  [{ staleLabel: '' }, 'not allowed to be empty'],
+  [{ staleLabel: false }, 'must be a string'],
+  [{ staleLabel: ['a', 'b'] }, 'must be a string'],
+  [{ markComment: true }, 'must be a string or false'],
+  [{ unmarkComment: true }, 'must be a string or false'],
+  [{ closeComment: true }, 'must be a string or false'],
+  [{ limitPerRun: 31 }, 'must be an integer between 1 and 30'],
+  [{ limitPerRun: 0 }, 'must be an integer between 1 and 30'],
+  [{ limitPerRun: 0.5 }, 'must be an integer between 1 and 30'],
+  [{ only: 'donuts' }, 'must be one of [issues, pulls, null]'],
+  [{ pulls: { daysUntilStale: 'no' } }, 'must be a number'],
+  [{ pulls: { lol: 'nope' } }, '"lol" is not allowed'],
+  [{ issues: { staleLabel: '' } }, 'not allowed to be empty'],
+  [{ _extends: true }, 'must be a string'],
+  [{ _extends: false }, 'must be a string']
 ]
 
 describe('schema', () => {
@@ -70,11 +70,11 @@ describe('schema', () => {
   })
 
   test('does not set defaults for pulls and issues', () => {
-    expect(schema.validate({pulls: {daysUntilStale: 90}}).value.pulls).toEqual({
+    expect(schema.validate({ pulls: { daysUntilStale: 90 } }).value.pulls).toEqual({
       daysUntilStale: 90
     })
 
-    expect(schema.validate({issues: {daysUntilStale: 90}}).value.issues).toEqual({
+    expect(schema.validate({ issues: { daysUntilStale: 90 } }).value.issues).toEqual({
       daysUntilStale: 90
     })
   })
@@ -89,7 +89,7 @@ describe('schema', () => {
 
   invalidConfigs.forEach(([example, message]) => {
     test(`${JSON.stringify(example)} is invalid`, () => {
-      const {error} = schema.validate(example)
+      const { error } = schema.validate(example)
       expect(error && error.toString()).toMatch(message)
     })
   })

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 process.env.LOG_LEVEL = 'fatal'
 
-const {Application} = require('probot')
+const { Application } = require('probot')
 const Stale = require('../lib/stale')
 const notFoundError = {
   code: 404,
@@ -44,11 +44,11 @@ describe('stale', () => {
   test(
     'removes the stale label and ignores if it has already been removed',
     async () => {
-      let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale', logger: app.log})
+      let stale = new Stale(github, { perform: true, owner: 'probot', repo: 'stale', logger: app.log })
 
       for (const type of ['pulls', 'issues']) {
         try {
-          await stale.unmark(type, {number: 123})
+          await stale.unmark(type, { number: 123 })
         } catch (_) {
           throw new Error('Should not have thrown an error')
         }
@@ -65,17 +65,17 @@ describe('stale', () => {
 
     const issues = []
     for (let i = 1; i <= issueCount; i++) {
-      const labels = (i <= staleCount) ? [{name: staleLabel}] : []
-      issues.push({number: i, labels: labels})
+      const labels = (i <= staleCount) ? [{ name: staleLabel }] : []
+      issues.push({ number: i, labels: labels })
     }
 
     const prs = []
     for (let i = 101; i <= 100 + issueCount; i++) {
-      const labels = (i <= 100 + staleCount) ? [{name: staleLabel}] : []
-      prs.push({number: i, labels: labels})
+      const labels = (i <= 100 + staleCount) ? [{ name: staleLabel }] : []
+      prs.push({ number: i, labels: labels })
     }
 
-    github.search.issues = ({q, sort, order, per_page}) => {
+    github.search.issues = ({ q, sort, order, per_page }) => {
       let items = []
       if (q.includes('is:pr')) {
         items = items.concat(prs.slice(0, per_page))
@@ -108,12 +108,12 @@ describe('stale', () => {
         comments++
         return Promise.resolve(notFoundError)
       })
-      github.issues.edit = ({owner, repo, number, state}) => {
+      github.issues.edit = ({ owner, repo, number, state }) => {
         if (state === 'closed') {
           closed++
         }
       }
-      github.issues.addLabels = ({owner, repo, number, labels}) => {
+      github.issues.addLabels = ({ owner, repo, number, labels }) => {
         if (labels.includes(staleLabel)) {
           labeledStale++
         }
@@ -122,7 +122,7 @@ describe('stale', () => {
       // Mock out GitHub client
       app.auth = () => Promise.resolve(github)
 
-      const stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale', logger: app.log})
+      const stale = new Stale(github, { perform: true, owner: 'probot', repo: 'stale', logger: app.log })
       stale.config.limitPerRun = limitPerRun
       stale.config.staleLabel = staleLabel
       stale.config.closeComment = 'closed'
@@ -138,9 +138,9 @@ describe('stale', () => {
   test(
     'should not close issues if daysUntilClose is configured as false',
     async () => {
-      let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale', logger: app.log})
+      let stale = new Stale(github, { perform: true, owner: 'probot', repo: 'stale', logger: app.log })
       stale.config.daysUntilClose = false
-      stale.getStale = jest.fn().mockImplementation(() => Promise.resolve({data: {items: []}}))
+      stale.getStale = jest.fn().mockImplementation(() => Promise.resolve({ data: { items: [] } }))
       stale.getClosable = jest.fn()
 
       await stale.markAndSweep('issues')
@@ -154,10 +154,10 @@ describe('stale', () => {
   test(
     'should not close issues if the keyword pulls or keyword issues is used, and daysUntilClose is configured as false',
     async () => {
-      let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale', logger: app.log})
+      let stale = new Stale(github, { perform: true, owner: 'probot', repo: 'stale', logger: app.log })
       stale.config.pulls = { daysUntilClose: false }
       stale.config.issues = { daysUntilClose: false }
-      stale.getStale = jest.fn().mockImplementation(() => Promise.resolve({data: {items: []}}))
+      stale.getStale = jest.fn().mockImplementation(() => Promise.resolve({ data: { items: [] } }))
       stale.getClosable = jest.fn()
 
       await stale.markAndSweep('issues')
@@ -171,10 +171,10 @@ describe('stale', () => {
   test(
     'should not close issues if only keyword is configured with the pulls value',
     async () => {
-      let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale', logger: app.log})
+      let stale = new Stale(github, { perform: true, owner: 'probot', repo: 'stale', logger: app.log })
       stale.config.only = 'pulls'
       stale.config.daysUntilClose = 1
-      stale.getStale = jest.fn().mockImplementation(() => Promise.resolve({data: {items: []}}))
+      stale.getStale = jest.fn().mockImplementation(() => Promise.resolve({ data: { items: [] } }))
       stale.getClosable = jest.fn()
 
       await stale.markAndSweep('issues')
@@ -185,10 +185,10 @@ describe('stale', () => {
   test(
     'should not close pull requests if only keyword is configured with the issues value',
     async () => {
-      let stale = new Stale(github, {perform: true, owner: 'probot', repo: 'stale', logger: app.log})
+      let stale = new Stale(github, { perform: true, owner: 'probot', repo: 'stale', logger: app.log })
       stale.config.only = 'issues'
       stale.config.daysUntilClose = 1
-      stale.getStale = jest.fn().mockImplementation(() => Promise.resolve({data: {items: []}}))
+      stale.getStale = jest.fn().mockImplementation(() => Promise.resolve({ data: { items: [] } }))
       stale.getClosable = jest.fn()
 
       await stale.markAndSweep('pulls')


### PR DESCRIPTION
resolves #159

This PR updates standard to v12 (see the v12 changelog [here](https://standardjs.com/changelog.html#1200---2018-08-28)). 

After installing v2, I ran `npx standard --fix` to resolve violations that standard was newly reporting.