### PR TITLE
Add support for overriding `daysUntilClose` for pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ daysUntilStale: 60
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
 daysUntilClose: 7
 
+# Number of days of inactivity before a Pull Request with the stale label is closed (overrides daysUntilClose for Pull Requests).
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilPullRequestStale: 7
+
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
   - pinned

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -4,6 +4,9 @@ const fields = {
   daysUntilStale: Joi.number()
     .description('Number of days of inactivity before an Issue or Pull Request becomes stale'),
 
+  daysUntilPullRequestStale: Joi.number()
+    .description('Number of days of inactivity before a Pull Request becomes stale (overrides daysUntilStale for PRs)'),
+
   daysUntilClose: Joi.alternatives().try(Joi.number(), Joi.boolean().only(false))
     .error(() => '"daysUntilClose" must be a number or false')
     .description('Number of days of inactivity before a stale Issue or Pull Request is closed. If disabled, issues still need to be closed manually, but will remain marked as stale.'),
@@ -42,6 +45,7 @@ const fields = {
 
 const schema = Joi.object().keys({
   daysUntilStale: fields.daysUntilStale.default(60),
+  daysUntilPullRequestStale: fields.daysUntilPullRequestStale,
   daysUntilClose: fields.daysUntilClose.default(7),
   exemptLabels: fields.exemptLabels.default(['pinned', 'security']),
   exemptProjects: fields.exemptProjects.default(false),

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -70,7 +70,13 @@ module.exports = class Stale {
     queryParts.push(exemptAssignees ? 'no:assignee' : '')
 
     const query = queryParts.join(' ')
-    const days = this.getConfigValue(type, 'days') || this.getConfigValue(type, 'daysUntilStale')
+    let days = this.getConfigValue(type, 'days')
+    if (!days && type === 'pulls') {
+      days = this.getConfigValue(type, 'daysUntilPullRequestStale')
+    }
+    if (!days) {
+      days = this.getConfigValue(type, 'daysUntilStale')
+    }
     return this.search(type, days, query)
   }
 

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -3,6 +3,8 @@ const schema = require('../lib/schema')
 const validConfigs = [
   [{ daysUntilClose: false }],
   [{ daysUntilClose: 1 }],
+  [{ daysUntilClose: false }],
+  [{ daysUntilPullRequestStale: 1 }],
   [{ exemptLabels: ['foo'] }],
   [{ exemptLabels: 'foo' }, { exemptLabels: ['foo'] }],
   [{ exemptLabels: null }],


### PR DESCRIPTION
This PR adds support for overriding `daysUntilClose` for pull requests, in the form of an optional key called `daysUntilPullRequestStale`.

-----
[View rendered README.md](https://github.com/status-im/stale/blob/feature/days-until-close-prs/README.md)