### PR TITLE
feat(monitoring): Allow NewRelic to be disabled

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -13,3 +13,8 @@ This plugin requires these **Permissions & events** for the GitHub App:
   - [x] Check the box for **Pull request review comment** events
 - Single File - **Read-only**
   - Path: `.github/stale.yml`
+
+**NOTE**: To disable newrelic when running your own instance, add the following key to your `.env` file:
+```bash
+DISABLE_NEW_RELIC=true
+```

--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
-require('newrelic')
+require('dotenv').config()
+
+if (!process.env.DISABLE_NEW_RELIC) {
+  require('newrelic')
+}
 
 const getConfig = require('probot-config')
 const createScheduler = require('probot-scheduler')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1790,9 +1790,9 @@
       }
     },
     "dotenv": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.1.0.tgz",
-      "integrity": "sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
     },
     "dtrace-provider": {
       "version": "0.8.7",
@@ -5696,6 +5696,13 @@
         "supports-color": "^5.5.0",
         "update-dotenv": "^1.1.0",
         "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.1.0.tgz",
+          "integrity": "sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw=="
+        }
       }
     },
     "probot-config": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "jest && standard"
   },
   "dependencies": {
+    "dotenv": "^7.0.0",
     "joi": "^14.0.0",
     "newrelic": "^5.2.1",
     "probot": "7.3.1",


### PR DESCRIPTION
Awesome app! I'm running an in house deployment of stale for a ghe instance and would love the option to disable new relic. We have no need for newrelic on stale internally, and it does make the startup logs a little less readable. 

It can definitely be a bit confusing seeing an error and stacktrace on start (even though the app does start just fine).

Error example:
```
->> npm start

> probot-stale@1.1.0 start /Users/thomask/Developer/personal/open_source/stale
> probot run ./index.js

14:41:33.076Z  INFO probot: Listening on http://localhost:3001
DEPRECATED (@octokit/rest): `apps.getInstallations()` is deprecated, use `apps.listInstallations()`
New Relic for Node.js halted startup due to an error:
Error: Not starting without license key!
    at onNextTick (/Users/thomask/Developer/personal/open_source/stale/node_modules/newrelic/lib/agent.js:154:16)
    at process._tickCallback (internal/process/next_tick.js:172:11)
```

This is fully backwards compatible (newrelic is enabled by default). I also see this has been brought up a few times in issues (https://github.com/probot/stale/issues/188) Let me know what you think, thanks!


-----
[View rendered docs/deploy.md](https://github.com/tknickman/stale/blob/optionally_disable_nr/docs/deploy.md)