### PR TITLE
Initial stab at collaboratless comment filter

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -23,6 +23,9 @@ const fields = {
   exemptAssignees: Joi.boolean()
     .description('Set to true to ignore issues with an assignee (defaults to false)'),
 
+  exemptIfNoCollaboratorComment: Joi.boolean()
+    .description('Issues are exempt from being stale if there are no comments from repo collaborators (defaults to false)'),
+
   staleLabel: Joi.string()
     .description('Label to use when marking as stale'),
 
@@ -51,6 +54,7 @@ const schema = Joi.object().keys({
   exemptProjects: fields.exemptProjects.default(false),
   exemptMilestones: fields.exemptMilestones.default(false),
   exemptAssignees: fields.exemptMilestones.default(false),
+  exemptIfNoCollaboratorComment: fields.exemptIfNoCollaboratorComment.default(false),
   staleLabel: fields.staleLabel.default('wontfix'),
   markComment: fields.markComment.default(
     'Is this still relevant? If so, what is blocking it? ' +

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -1,3 +1,4 @@
+const includes = require('lodash.includes');
 const schema = require('./schema')
 const maxActionsPerRun = 30
 
@@ -62,13 +63,14 @@ module.exports = class Stale {
     }
   }
 
-  getStale (type) {
+  async getStale (type) {
     const onlyLabels = this.getConfigValue(type, 'onlyLabels')
     const staleLabel = this.getConfigValue(type, 'staleLabel')
     const exemptLabels = this.getConfigValue(type, 'exemptLabels')
     const exemptProjects = this.getConfigValue(type, 'exemptProjects')
     const exemptMilestones = this.getConfigValue(type, 'exemptMilestones')
     const exemptAssignees = this.getConfigValue(type, 'exemptAssignees')
+    const exemptIfNoCollaboratorComment = this.getConfigValue(type, 'exemptIfNoCollaboratorComment')
     const labels = [staleLabel].concat(exemptLabels)
     const queryParts = labels.map(label => `-label:"${label}"`)
     queryParts.concat(onlyLabels.map(label => `label:"${label}"`))
@@ -80,7 +82,13 @@ module.exports = class Stale {
 
     const query = queryParts.join(' ')
     const days = this.getConfigValue(type, 'days') || this.getConfigValue(type, 'daysUntilStale')
-    return this.search(type, days, query)
+    const searchResults = await this.search(type, days, query)
+
+    if (exemptIfNoCollaboratorComment) {
+      return filterIssuesWithoutMaintainerComments(searchResults)
+    } else {
+      return searchResults
+    }
   }
 
   getClosable (type) {
@@ -110,6 +118,30 @@ module.exports = class Stale {
 
     this.logger.info(params, 'searching %s/%s for stale issues', owner, repo)
     return this.github.search.issues(params)
+  }
+
+  async filterIssuesWithoutMaintainerComments(issues) {
+    const { owner, repo } = this.config
+    const github = this.github
+
+    const collaborators = await github.repos.listCollaborators({
+      owner,
+      repo
+    })
+
+    const collaboratorUsernames = collaborators.map(c => c.login)
+
+    return Promise.all(issues.filter(async (issue) => {
+      const comments = github.issues.listComments({
+        owner,
+        repo,
+        issue_number: issue.number
+      });
+
+      return comments.find(comment => {
+        return includes(collaboratorUsernames, comment.user.login)
+      })
+    }))
   }
 
   async markIssue (type, issue) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@hapi/joi": "^15.0.0",
+    "lodash.includes": "^4.3.0",
     "newrelic": "^5.2.1",
     "probot": "7.3.1",
     "probot-config": "^0.1.0",

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -17,6 +17,8 @@ const validConfigs = [
   [{ exemptMilestones: false }],
   [{ exemptAssignees: true }],
   [{ exemptAssignees: false }],
+  [{exemptIfNoCollaboratorComment: true}],
+  [{exemptIfNoCollaboratorComment: false}],
   [{ staleLabel: 'stale' }],
   [{ markComment: 'stale yo' }],
   [{ markComment: false }],
@@ -67,6 +69,7 @@ describe('schema', () => {
       exemptProjects: false,
       exemptMilestones: false,
       exemptAssignees: false,
+      exemptIfNoCollaboratorComment: false,
       staleLabel: 'wontfix',
       perform: true,
       markComment: 'Is this still relevant? If so, what is blocking it? ' +


### PR DESCRIPTION
First stab at solving https://github.com/probot/stale/issues/147 I guess we can thank Stale for constantly poking me about this issue I raised years ago.

I've not actually run this yet to check it works or written any tests, I wanted to check two things first.
1. Is this actually a feature that we should add to probot? The issue suggests it's a feature some people desire, I've no idea how many people use stale though so I've no idea if it'll be worth maintaing this extra option.
2. Is this approach reasonable? I expect some change suggestions (especially to my rubbish naming) but it's worth disscussing the general approach of the code. The one problem I forsee is that this requires interrogating every issue for it's comments every time stale runs. This could potentially add a heavy load to Stale and it's understandable if we don't want to manage it. On the other hand, stale isn't something that needs to run "quickly" so maybe this is okay.

What do we think?