### PR TITLE
Change default label from 'wontfix' to 'stale'

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ exemptMilestones: false
 exemptAssignees: false
 
 # Label to use when marking as stale
-staleLabel: wontfix
+staleLabel: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -51,7 +51,7 @@ const schema = Joi.object().keys({
   exemptProjects: fields.exemptProjects.default(false),
   exemptMilestones: fields.exemptMilestones.default(false),
   exemptAssignees: fields.exemptMilestones.default(false),
-  staleLabel: fields.staleLabel.default('wontfix'),
+  staleLabel: fields.staleLabel.default('stale'),
   markComment: fields.markComment.default(
     'Is this still relevant? If so, what is blocking it? ' +
     'Is there anything you can do to help move it forward?' +

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -67,7 +67,7 @@ describe('schema', () => {
       exemptProjects: false,
       exemptMilestones: false,
       exemptAssignees: false,
-      staleLabel: 'wontfix',
+      staleLabel: 'stale',
       perform: true,
       markComment: 'Is this still relevant? If so, what is blocking it? ' +
         'Is there anything you can do to help move it forward?' +


### PR DESCRIPTION
Fixes #109 and #74.

Support for this change has been expressed by @patcon, @christianbundy, @sindresorhus, @paulmelnikow, @dwijnand, @darthmaim and @max-sixty in the issues linked above, and likely others who may have subscribed to them but haven't added comments or reactions to the discussion threads.

-----
[View rendered README.md](https://github.com/waldyrious/stale/blob/change-default-stale-label/README.md)