### PR TITLE
Await the async result of unmarking an issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = async app => {
         context.payload.label.name === stale.config.staleLabel
 
       if (stale.hasStaleLabel(type, issue) && issue.state !== 'closed' && !staleLabelAdded) {
-        stale.unmarkIssue(type, issue)
+        await stale.unmarkIssue(type, issue)
       }
     }
   }


### PR DESCRIPTION
The `unmark` functionality is neither returning nor `await`-ing the `Promise` returned from the call to `Stale#unmarkIssue`.

This is not strictly necessary but would be the best practice to avoid hypothetical race conditions when invoking `unmark` but then continuing on before actually verifying the status/result of the inner activity.

If this is specifically  **not** desired, then I would instead suggest adding a comment here to explain why.