### PR TITLE
README.md - Rewording and spacing corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ limitPerRun: 30
 
 ## How are issues and pull requests considered stale?
 
-The app uses GitHub's [updated](https://help.github.com/articles/searching-issues/#search-based-on-when-an-issue-or-pull-request-was-created-or-last-updated) search qualifier to determine staleness. Any change to an issues and pull request is considered an update, including comments, changing labels, applying or removing milestones,  or pushing commits.
+The app uses GitHub's [updated](https://help.github.com/articles/searching-issues/#search-based-on-when-an-issue-or-pull-request-was-created-or-last-updated) search qualifier to determine staleness. Any change to issues and pull requests is considered an update, including comments, changing labels, applying or removing milestones, or pushing commits.
 
 An easy way to check and see which issues or pull requests will initially be marked as stale is to add the `updated` search qualifier to either the issue or pull request page filter for your repository: `updated:<2017-07-01`. Adjust the date to be 60 days ago (or whatever you set for `daysUntilStale`) to see which issues or pull requests will be marked.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ limitPerRun: 30
 
 ## How are issues and pull requests considered stale?
 
-The app uses GitHub's [updated](https://help.github.com/articles/searching-issues/#search-based-on-when-an-issue-or-pull-request-was-created-or-last-updated) search qualifier to determine staleness. Any change to issues and pull requests is considered an update, including comments, changing labels, applying or removing milestones, or pushing commits.
+The app uses GitHub's [updated](https://help.github.com/articles/searching-issues/#search-based-on-when-an-issue-or-pull-request-was-created-or-last-updated) search qualifier to determine staleness. Any change to an issue or pull request is considered an update, including comments, changing labels, applying or removing milestones, or pushing commits.
 
 An easy way to check and see which issues or pull requests will initially be marked as stale is to add the `updated` search qualifier to either the issue or pull request page filter for your repository: `updated:<2017-07-01`. Adjust the date to be 60 days ago (or whatever you set for `daysUntilStale`) to see which issues or pull requests will be marked.
 


### PR DESCRIPTION
Rewording the description under _How are issues and pull requests considered stale?_ and cleaned up a wild double-space.