### PR TITLE
Add label after closing an issue

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -26,6 +26,12 @@ const fields = {
   staleLabel: Joi.string()
     .description('Label to use when marking as stale'),
 
+  // closedLabel: Joi.string()
+  //   .description('Label to use when clsoing an issue'),
+  closedLabel: Joi.alternatives().try(Joi.string(), Joi.boolean().only(false))
+    .error(() => '"closedLabel" must be a string or false')
+    .description('Label to use when issue is closed. Set to `false` to disable'),
+    
   markComment: Joi.alternatives().try(Joi.string(), Joi.any().only(false))
     .error(() => '"markComment" must be a string or false')
     .description('Comment to post when marking as stale. Set to `false` to disable'),
@@ -52,6 +58,8 @@ const schema = Joi.object().keys({
   exemptMilestones: fields.exemptMilestones.default(false),
   exemptAssignees: fields.exemptMilestones.default(false),
   staleLabel: fields.staleLabel.default('wontfix'),
+  // closedLabel: fields.closedLabel.default('closedByBot'),
+  closedLabel: fields.closeComment.default(false),
   markComment: fields.markComment.default(
     'Is this still relevant? If so, what is blocking it? ' +
     'Is there anything you can do to help move it forward?' +

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -26,8 +26,6 @@ const fields = {
   staleLabel: Joi.string()
     .description('Label to use when marking as stale'),
 
-  // closedLabel: Joi.string()
-  //   .description('Label to use when clsoing an issue'),
   closedLabel: Joi.alternatives().try(Joi.string(), Joi.boolean().only(false))
     .error(() => '"closedLabel" must be a string or false')
     .description('Label to use when issue is closed. Set to `false` to disable'),
@@ -58,7 +56,6 @@ const schema = Joi.object().keys({
   exemptMilestones: fields.exemptMilestones.default(false),
   exemptAssignees: fields.exemptMilestones.default(false),
   staleLabel: fields.staleLabel.default('wontfix'),
-  // closedLabel: fields.closedLabel.default('closedByBot'),
   closedLabel: fields.closeComment.default(false),
   markComment: fields.markComment.default(
     'Is this still relevant? If so, what is blocking it? ' +

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -36,6 +36,7 @@ module.exports = class Stale {
     await this.sweep(type)
   }
 
+  // Mark an issue
   async mark (type) {
     await this.ensureStaleLabelExists(type)
 
@@ -48,6 +49,19 @@ module.exports = class Stale {
     )
   }
 
+
+  async closeDriver (issue) {
+
+    this.remainingActions = 30
+
+    this.close('issue', issue)
+    // const closableItems = (await this.getClosable(type)).data.items
+    // const closableItems = [issue]
+
+
+  }
+
+  // Sweep an issue
   async sweep (type) {
     const { owner, repo } = this.config
     const daysUntilClose = this.getConfigValue(type, 'daysUntilClose')
@@ -155,7 +169,13 @@ module.exports = class Stale {
       if (closeComment) {
         await this.github.issues.createComment({ owner, repo, number, body: closeComment })
       }
-      return this.github.issues.edit({ owner, repo, number, state: 'closed' })
+      const closedLabel = this.getConfigValue(type, 'closedLabel')
+      if (closedLabel && closedLabel.trim().length != 0){
+        await this.ensureClosedLabelExists(type)
+        this.github.issues.addLabels({ owner, repo, number, labels: [closedLabel] })
+      }
+      
+      return this.github.issues.update({ owner, repo, number, state: 'closed' })
     } else {
       this.logger.info('%s/%s#%d would have been closed (dry-run)', owner, repo, number)
     }
@@ -211,6 +231,15 @@ module.exports = class Stale {
 
     return this.github.issues.getLabel({ owner, repo, name: staleLabel }).catch(() => {
       return this.github.issues.createLabel({ owner, repo, name: staleLabel, color: 'ffffff' })
+    })
+  }
+
+  async ensureClosedLabelExists (type) {
+    const { owner, repo } = this.config
+    const closedLabel = this.getConfigValue(type, 'closedLabel')
+
+    return this.github.issues.getLabel({ owner, repo, name: closedLabel }).catch(() => {
+      return this.github.issues.createLabel({ owner, repo, name: closedLabel, color: 'E99695' })
     })
   }
 

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -36,7 +36,6 @@ module.exports = class Stale {
     await this.sweep(type)
   }
 
-  // Mark an issue
   async mark (type) {
     await this.ensureStaleLabelExists(type)
 
@@ -49,19 +48,6 @@ module.exports = class Stale {
     )
   }
 
-
-  async closeDriver (issue) {
-
-    this.remainingActions = 30
-
-    this.close('issue', issue)
-    // const closableItems = (await this.getClosable(type)).data.items
-    // const closableItems = [issue]
-
-
-  }
-
-  // Sweep an issue
   async sweep (type) {
     const { owner, repo } = this.config
     const daysUntilClose = this.getConfigValue(type, 'daysUntilClose')
@@ -169,6 +155,7 @@ module.exports = class Stale {
       if (closeComment) {
         await this.github.issues.createComment({ owner, repo, number, body: closeComment })
       }
+      
       const closedLabel = this.getConfigValue(type, 'closedLabel')
       if (closedLabel && closedLabel.trim().length != 0){
         await this.ensureClosedLabelExists(type)

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "probot-stale",
+  "name": "ollis-probot-stale",
   "version": "1.1.0",
   "description": "A GitHub App built with Probot that closes abandoned Issues and Pull Requests after a period of inactivity.",
   "author": "Brandon Keepers",
   "license": "ISC",
   "homepage": "https://probot.github.io/apps/stale/",
-  "bugs": "https://github.com/probot/stale/issues",
+  "bugs": "https://github.com/OllisGit/stale/issues",
   "keywords": [
     "probot",
     "github",
     "probot-app"
   ],
-  "repository": "https://github.com/probot/stale",
+  "repository": "https://github.com/OllisGit/stale",
   "scripts": {
     "start": "probot run ./index.js",
     "test": "jest && standard"

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "ollis-probot-stale",
+  "name": "probot-stale",
   "version": "1.1.0",
   "description": "A GitHub App built with Probot that closes abandoned Issues and Pull Requests after a period of inactivity.",
   "author": "Brandon Keepers",
   "license": "ISC",
   "homepage": "https://probot.github.io/apps/stale/",
-  "bugs": "https://github.com/OllisGit/stale/issues",
+  "bugs": "https://github.com/probot/stale/issues",
   "keywords": [
     "probot",
     "github",
     "probot-app"
   ],
-  "repository": "https://github.com/OllisGit/stale",
+  "repository": "https://github.com/probot/stale",
   "scripts": {
     "start": "probot run ./index.js",
     "test": "jest && standard"


### PR DESCRIPTION
This PR is related to this issue #298 

Now you can the following attribute to the stale.yml file and after an issue is closed by the bot an label is added.
```
closedLabel: "closedByBot"
```
I the named label doesn't exists, it is created.

You can disable the label assignment by switching the config to false.
```
closedLabel: false
```
  