### PR TITLE
use `not_planned` close reason

### DIFF
--- a/lib/stale.js
+++ b/lib/stale.js
@@ -155,7 +155,7 @@ module.exports = class Stale {
       if (closeComment) {
         await this.github.issues.createComment({ owner, repo, number, body: closeComment })
       }
-      return this.github.issues.edit({ owner, repo, number, state: 'closed' })
+      return this.github.issues.update({ owner, repo, number, state: 'closed', state_reason: 'not_planned' })
     } else {
       this.logger.info('%s/%s#%d would have been closed (dry-run)', owner, repo, number)
     }

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -30,7 +30,7 @@ describe('stale', () => {
         createLabel: issueAction,
         addLabels: issueAction,
         createComment: issueAction,
-        edit: issueAction
+        update: issueAction
       },
       search: {
         issues: issueAction
@@ -108,8 +108,9 @@ describe('stale', () => {
         comments++
         return Promise.resolve(notFoundError)
       })
-      github.issues.edit = ({ owner, repo, number, state }) => {
+      github.issues.update = ({ owner, repo, number, state, state_reason }) => {
         if (state === 'closed') {
+          expect(state_reason).toBe('not_planned')
           closed++
         }
       }


### PR DESCRIPTION
closes #379

https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/ says

>We have added a new state_reason attribute to our REST API, GraphQL API and webhooks. These are currently in preview and will be fully shipped in the upcoming week.

but it looks the docs aren't updated given https://github.com/actions/stale/issues/744 has been done I'm assuming it works.

Not sure if you also want an option for this or happy just switching to it?